### PR TITLE
v5.6.1 - Fix crossfade regression in default mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
-## v5.6.0 (In Development)
+## v5.6.1 - 2025-12-17
+
+### Fixed
+- **Crossfade Regression in Default Mode**: Fixed images not displaying in default scaling mode without explicit card_height or max_height
+  - Root cause: Crossfade layers positioned absolutely needed container with explicit dimensions
+  - Solution: Override absolute positioning in default mode using CSS Grid with `grid-area: 1 / 1` to stack layers
+  - Layers now use `position: static` in default mode and participate in document flow
+  - Container sizes naturally to fit image dimensions while respecting max-height constraints
+  - Crossfade transitions work correctly with proper centering in all configurations
+
+## v5.6.0 - 2025-12-16
+
 ### Fixed
 - **Metadata Display Bug**
   - Fixed metadata overlay not displaying even when data available (filename, location, dates)

--- a/ha-media-card.js
+++ b/ha-media-card.js
@@ -1,5 +1,5 @@
 /** 
- * Media Card v5.6.0
+ * Media Card v5.6.1
  */
 
 import { LitElement, html, css } from 'https://unpkg.com/lit@3/index.js?module'
@@ -10280,6 +10280,7 @@ class MediaCard extends LitElement {
     }
     
     :host([data-card-height]:not([data-aspect-mode])) img,
+    :host([data-card-height]:not([data-aspect-mode])) .image-layer,
     :host([data-card-height]:not([data-aspect-mode])) video {
       max-height: 100%;
       max-width: 100%;
@@ -10291,9 +10292,24 @@ class MediaCard extends LitElement {
     
     /* Default mode (no aspect-mode, no card-height): Center images and apply max-height */
     :host(:not([data-aspect-mode]):not([data-card-height])) .media-container {
-      display: flex;
-      align-items: center;
-      justify-content: center;
+      display: grid;
+      place-items: center;
+    }
+    
+    /* V5.6: Crossfade layers stack via grid in default mode */
+    :host(:not([data-aspect-mode]):not([data-card-height])) .image-layer {
+      position: static !important;
+      top: auto;
+      left: auto;
+      transform: none;
+      grid-area: 1 / 1;
+      max-height: var(--media-max-height, 400px);
+      max-width: 100%;
+      width: auto;
+      height: auto;
+      object-fit: contain;
+      justify-self: center;
+      align-self: center;
     }
     
     :host(:not([data-aspect-mode]):not([data-card-height])) img {
@@ -16462,7 +16478,7 @@ if (!window.customCards.some(card => card.type === 'media-card')) {
 }
 
 console.info(
-  '%c  MEDIA-CARD  %c  v5.6.0 Loaded  ',
+  '%c  MEDIA-CARD  %c  v5.6.1 Loaded  ',
   'color: lime; font-weight: bold; background: black',
   'color: white; font-weight: bold; background: green'
 );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-media-card",
-  "version": "5.6.0",
+  "version": "5.6.1",
   "description": "Home Assistant Lovelace card for displaying media with slideshow, favorites, and metadata",
   "type": "module",
   "scripts": {

--- a/src/ui/media-card.js
+++ b/src/ui/media-card.js
@@ -6565,6 +6565,7 @@ export class MediaCard extends LitElement {
     }
     
     :host([data-card-height]:not([data-aspect-mode])) img,
+    :host([data-card-height]:not([data-aspect-mode])) .image-layer,
     :host([data-card-height]:not([data-aspect-mode])) video {
       max-height: 100%;
       max-width: 100%;
@@ -6576,9 +6577,24 @@ export class MediaCard extends LitElement {
     
     /* Default mode (no aspect-mode, no card-height): Center images and apply max-height */
     :host(:not([data-aspect-mode]):not([data-card-height])) .media-container {
-      display: flex;
-      align-items: center;
-      justify-content: center;
+      display: grid;
+      place-items: center;
+    }
+    
+    /* V5.6: Crossfade layers stack via grid in default mode */
+    :host(:not([data-aspect-mode]):not([data-card-height])) .image-layer {
+      position: static !important;
+      top: auto;
+      left: auto;
+      transform: none;
+      grid-area: 1 / 1;
+      max-height: var(--media-max-height, 400px);
+      max-width: 100%;
+      width: auto;
+      height: auto;
+      object-fit: contain;
+      justify-self: center;
+      align-self: center;
     }
     
     :host(:not([data-aspect-mode]):not([data-card-height])) img {


### PR DESCRIPTION
### Fixed
- **Crossfade Regression in Default Mode**: Fixed images not displaying in default scaling mode without explicit card_height or max_height
  - Root cause: Crossfade layers positioned absolutely needed container with explicit dimensions
  - Solution: Override absolute positioning in default mode using CSS Grid with `grid-area: 1 / 1` to stack layers
  - Layers now use `position: static` in default mode and participate in document flow
  - Container sizes naturally to fit image dimensions while respecting max-height constraints
  - Crossfade transitions work correctly with proper centering in all configurations
