### PR TITLE
fix: panel thumbnail clicks not changing main image (v5.6.6)

### DIFF
--- a/ha-media-card.js
+++ b/ha-media-card.js
@@ -1,5 +1,5 @@
 /** 
- * Media Card v5.6.5
+ * Media Card v5.6.6
  */
 
 import { LitElement, html, css } from 'https://unpkg.com/lit@3/index.js?module'
@@ -5387,7 +5387,7 @@ class MediaCard extends LitElement {
       return;
     }
     
-    this._log(`📱 Loading panel item ${index + 1}/${this._panelQueue.length}:`, item.filename || item.path);
+    console.log('[MediaCard] 📱 Loading panel item', index + 1, '/', this._panelQueue.length, ':', item.filename || item.path, 'Panel mode:', this._panelMode);
     
     // Update panel index
     this._panelQueueIndex = index;
@@ -5414,6 +5414,10 @@ class MediaCard extends LitElement {
     // V5.7: Store in pending state - will apply when image/video loads
     this._pendingMediaPath = mediaUri;
     this._pendingMetadata = metadata;
+    
+    // V5.7: Panel navigation doesn't use queue navigation indices - set to special marker
+    // This tells _resolveMediaUrl to skip stale navigation checks (only relevant for queue nav)
+    this._pendingNavigationIndex = -1; // -1 = panel navigation, not queue navigation
     
     // Update deprecated state for compatibility
     if (this._panelMode === 'burst') {
@@ -17416,7 +17420,7 @@ if (!window.customCards.some(card => card.type === 'media-card')) {
 }
 
 console.info(
-  '%c  MEDIA-CARD  %c  v5.6.5 Loaded  ',
+  '%c  MEDIA-CARD  %c  v5.6.6 Loaded  ',
   'color: lime; font-weight: bold; background: black',
   'color: white; font-weight: bold; background: green'
 );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-media-card",
-  "version": "5.6.5",
+  "version": "5.6.6",
   "description": "Home Assistant Lovelace card for displaying media with slideshow, favorites, and metadata",
   "type": "module",
   "scripts": {

--- a/src/ui/media-card.js
+++ b/src/ui/media-card.js
@@ -1605,7 +1605,7 @@ export class MediaCard extends LitElement {
       return;
     }
     
-    this._log(`📱 Loading panel item ${index + 1}/${this._panelQueue.length}:`, item.filename || item.path);
+    console.log('[MediaCard] 📱 Loading panel item', index + 1, '/', this._panelQueue.length, ':', item.filename || item.path, 'Panel mode:', this._panelMode);
     
     // Update panel index
     this._panelQueueIndex = index;
@@ -1632,6 +1632,10 @@ export class MediaCard extends LitElement {
     // V5.7: Store in pending state - will apply when image/video loads
     this._pendingMediaPath = mediaUri;
     this._pendingMetadata = metadata;
+    
+    // V5.7: Panel navigation doesn't use queue navigation indices - set to special marker
+    // This tells _resolveMediaUrl to skip stale navigation checks (only relevant for queue nav)
+    this._pendingNavigationIndex = -1; // -1 = panel navigation, not queue navigation
     
     // Update deprecated state for compatibility
     if (this._panelMode === 'burst') {


### PR DESCRIPTION
CRITICAL BUG FIX:
- Fixed Through the Years, Burst, and Related Photos panels not updating main image when clicking thumbnails
- Root cause: _loadPanelItem wasn't setting _pendingNavigationIndex, causing stale navigation check to abort layer updates
- Solution: Set _pendingNavigationIndex = -1 to mark panel navigation and bypass queue-based stale checks
- Console showed: 'Skipping stale layer update (expected: null, current: 0)'
- Affects all panel modes except Queue Preview