### PR TITLE
5.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v5.8.1 - 2026-04-06
+
+### Changed
+- **HACS integration renamed to "Media Card"**: The card name in HACS has been simplified from "Home Assistant Media Card" to "Media Card" for better discoverability in the HACS UI panel.
+
+### Fixed
+- **Slideshow freezes after video when next item is an image**: After a video played to completion, the slideshow timer would log "Timer skipped - navigation in progress" indefinitely and never advance
+  - Root cause: `_isCurrentItemVideo()` used `this.mediaUrl` to detect video items, but in `_setMediaUrl()` the URL hasn't been updated yet — so when a JPG followed an mp4, `this.mediaUrl` still held the old mp4 URL and the JPG was incorrectly classified as a video
+  - The video code path clears both image layers then sets `this.mediaUrl` to the JPG URL; `_renderMedia` then rendered nothing (no `<img>`), `_onMediaLoaded` never fired, and `_navigatingAway` stayed `true` permanently
+  - Fix: `_isCurrentItemVideo()` now accepts an optional `resolvedUrl` parameter; `_setMediaUrl` passes the incoming URL so the type check uses the new URL rather than the stale previous one
+
 ## v5.8.0 - 2026-03-26
 
 ### Added

--- a/ha-media-card.js
+++ b/ha-media-card.js
@@ -1,5 +1,5 @@
 /** 
- * Media Card v5.8.0
+ * Media Card v5.8.1
  */
 
 // Async wrapper for dynamic Lit loading (supports offline mode)
@@ -7283,7 +7283,12 @@ class MediaCard extends LitElement {
     // returns false and _setMediaUrl takes the image crossfade path, which never calls
     // videoElement.load().  Lit reuses the same <video> DOM node between navigations and the
     // browser does NOT auto-reload when <source src> changes — so the video never plays.
-    const isVideo = this._isVideoFile(url) || this._isCurrentItemVideo();
+    // IMPORTANT: Pass `url` (the new URL) to _isCurrentItemVideo() so it checks the incoming
+    // URL rather than this.mediaUrl, which still holds the PREVIOUS item's URL at this point.
+    // Without this, a JPG following an mp4 is incorrectly classified as a video: both image
+    // layers get cleared, _renderMedia renders nothing, _onMediaLoaded never fires, and
+    // _navigatingAway stays true — freezing the slideshow timer permanently.
+    const isVideo = this._isVideoFile(url) || this._isCurrentItemVideo(url);
     
     // For images, validate they exist before displaying (MediaIndexProvider only)
     if (!isVideo) {
@@ -11485,12 +11490,19 @@ class MediaCard extends LitElement {
    * and other integration sources that use opaque URIs with no extension.
    * This method also checks media_content_type (set from HA browse_media response where
    * Reolink returns media_class='video') and the resolved mediaUrl.
+   *
+   * @param {string|null} resolvedUrl - The newly resolved URL being set. When provided (e.g.
+   *   from _setMediaUrl before this.mediaUrl is updated), this URL is used instead of the
+   *   potentially stale this.mediaUrl. Omit to use this.mediaUrl (safe once URL is current).
    */
-  _isCurrentItemVideo() {
+  _isCurrentItemVideo(resolvedUrl = null) {
     // Check media_content_type first – most reliable for integration sources (Reolink, Immich, etc.)
     if (this.currentMedia?.media_content_type?.startsWith('video')) return true;
-    // Fall back to extension-based detection on the canonical ID or resolved URL
-    return this._isVideoFile(this.currentMedia?.media_content_id) || this._isVideoFile(this.mediaUrl);
+    // Fall back to extension-based detection on the canonical ID or resolved URL.
+    // NOTE: When called from _setMediaUrl, resolvedUrl is the NEW url being set — this.mediaUrl
+    // is still the PREVIOUS item's URL at that point (stale). Always pass resolvedUrl from
+    // _setMediaUrl to avoid classifying a JPG as a video just because the previous item was an mp4.
+    return this._isVideoFile(this.currentMedia?.media_content_id) || this._isVideoFile(resolvedUrl ?? this.mediaUrl);
   }
 
   /**
@@ -19367,7 +19379,7 @@ if (!window.customCards.some(card => card.type === 'media-card')) {
 }
 
 console.info(
-  '%c  MEDIA-CARD  %c  v5.8.0 Loaded  ',
+  '%c  MEDIA-CARD  %c  v5.8.1 Loaded  ',
   'color: lime; font-weight: bold; background: black',
   'color: white; font-weight: bold; background: green'
 );

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,4 @@
 {
-  "name": "Home Assistant Media Card",
+  "name": "Media Card",
   "homeassistant": "2021.12.0"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-media-card",
-  "version": "5.8.0",
+  "version": "5.8.1",
   "description": "Home Assistant dashboard card for displaying media with slideshow, favorites, and metadata",
   "type": "module",
   "scripts": {

--- a/src/ui/media-card.js
+++ b/src/ui/media-card.js
@@ -2662,7 +2662,12 @@ export class MediaCard extends LitElement {
     // returns false and _setMediaUrl takes the image crossfade path, which never calls
     // videoElement.load().  Lit reuses the same <video> DOM node between navigations and the
     // browser does NOT auto-reload when <source src> changes — so the video never plays.
-    const isVideo = this._isVideoFile(url) || this._isCurrentItemVideo();
+    // IMPORTANT: Pass `url` (the new URL) to _isCurrentItemVideo() so it checks the incoming
+    // URL rather than this.mediaUrl, which still holds the PREVIOUS item's URL at this point.
+    // Without this, a JPG following an mp4 is incorrectly classified as a video: both image
+    // layers get cleared, _renderMedia renders nothing, _onMediaLoaded never fires, and
+    // _navigatingAway stays true — freezing the slideshow timer permanently.
+    const isVideo = this._isVideoFile(url) || this._isCurrentItemVideo(url);
     
     // For images, validate they exist before displaying (MediaIndexProvider only)
     if (!isVideo) {
@@ -6864,12 +6869,19 @@ export class MediaCard extends LitElement {
    * and other integration sources that use opaque URIs with no extension.
    * This method also checks media_content_type (set from HA browse_media response where
    * Reolink returns media_class='video') and the resolved mediaUrl.
+   *
+   * @param {string|null} resolvedUrl - The newly resolved URL being set. When provided (e.g.
+   *   from _setMediaUrl before this.mediaUrl is updated), this URL is used instead of the
+   *   potentially stale this.mediaUrl. Omit to use this.mediaUrl (safe once URL is current).
    */
-  _isCurrentItemVideo() {
+  _isCurrentItemVideo(resolvedUrl = null) {
     // Check media_content_type first – most reliable for integration sources (Reolink, Immich, etc.)
     if (this.currentMedia?.media_content_type?.startsWith('video')) return true;
-    // Fall back to extension-based detection on the canonical ID or resolved URL
-    return this._isVideoFile(this.currentMedia?.media_content_id) || this._isVideoFile(this.mediaUrl);
+    // Fall back to extension-based detection on the canonical ID or resolved URL.
+    // NOTE: When called from _setMediaUrl, resolvedUrl is the NEW url being set — this.mediaUrl
+    // is still the PREVIOUS item's URL at that point (stale). Always pass resolvedUrl from
+    // _setMediaUrl to avoid classifying a JPG as a video just because the previous item was an mp4.
+    return this._isVideoFile(this.currentMedia?.media_content_id) || this._isVideoFile(resolvedUrl ?? this.mediaUrl);
   }
 
   /**


### PR DESCRIPTION
## Changed
- **HACS integration renamed to "Media Card"**: The card name in HACS has been simplified from "Home Assistant Media Card" to "Media Card" for better discoverability in the HACS UI panel.

### Fixed
- **Slideshow freezes after video when next item is an image**: After a video played to completion, the slideshow timer would log "Timer skipped - navigation in progress" indefinitely and never advance
  - Root cause: `_isCurrentItemVideo()` used `this.mediaUrl` to detect video items, but in `_setMediaUrl()` the URL hasn't been updated yet — so when a JPG followed an mp4, `this.mediaUrl` still held the old mp4 URL and the JPG was incorrectly classified as a video
  - The video code path clears both image layers then sets `this.mediaUrl` to the JPG URL; `_renderMedia` then rendered nothing (no `<img>`), `_onMediaLoaded` never fired, and `_navigatingAway` stayed `true` permanently
  - Fix: `_isCurrentItemVideo()` now accepts an optional `resolvedUrl` parameter; `_setMediaUrl` passes the incoming URL so the type check uses the new URL rather than the stale previous one
