### PR TITLE
v5.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## v5.10.0 - 2026-04-22
 
 ### Added
-- **Shared Queue** (`shared_queue_id`): Two cards on different dashboard views can share a single navigation queue. Set the same `shared_queue_id` string on both cards and they will stay in sync — switching from one view to the other shows the same image and preserves the full navigation history so back/forward work across both cards. Uses `localStorage` for persistence across view switches and a `CustomEvent` for immediate same-window sync. Configure via the visual editor ("Shared Queue ID" in the Image Options section) or in YAML as `shared_queue_id: "my_queue"`.
+- **Shared Queue** (`shared_queue_id`): Multiple cards across any number of views — or across different devices and browsers — share a single navigation queue and stay in lock-step. Set the same `shared_queue_id` string on every participating card and they will always show the same image with a shared navigation history so back/forward work everywhere. Three complementary transports keep all cards in sync:
+  - **Same-window**: `CustomEvent` bus for zero-latency sync between cards on the same browser tab
+  - **Cross-view persistence**: `localStorage` so switching to a different dashboard view immediately shows the current image
+  - **Cross-device**: When the `media_index` source is active, the card writes sync state through the `media_index.update_sync_state` service and listens for the resulting `media_index_sync_state` HA event — keeping wall tablets, mobile phones, and any other device in sync in real time
+  - Pause/resume syncs reliably across all devices: only explicit user pause actions propagate; automatic navigation advances never accidentally override a peer's pause state
+  - The current image's metadata (date, location, camera) is included in every sync payload so receiving cards display the correct information without making their own service calls
+  - Configure via the visual editor ("Shared Queue ID" in the Image Options section) or in YAML as `shared_queue_id: "my_queue"`
 
 ### Fixed
 - **Action button colors washed out on light and frosted-glass themes**: Button backgrounds were derived from `--rgb-card-background-color`, which resolves to near-white on many light themes, making icons invisible. Fixed by using hardcoded dark semi-transparent backgrounds (`rgba(0,0,0,0.55)`) and explicit white icon colors. Active-state colors (mute, pause, info, burst, queue, favorite) are now set directly on the `ha-icon` element so they work correctly on all themes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v5.10.0 - 2026-04-22
+
+### Added
+- **Shared Queue** (`shared_queue_id`): Two cards on different dashboard views can share a single navigation queue. Set the same `shared_queue_id` string on both cards and they will stay in sync — switching from one view to the other shows the same image and preserves the full navigation history so back/forward work across both cards. Uses `localStorage` for persistence across view switches and a `CustomEvent` for immediate same-window sync. Configure via the visual editor ("Shared Queue ID" in the Image Options section) or in YAML as `shared_queue_id: "my_queue"`.
+
+### Fixed
+- **Action button colors washed out on light and frosted-glass themes**: Button backgrounds were derived from `--rgb-card-background-color`, which resolves to near-white on many light themes, making icons invisible. Fixed by using hardcoded dark semi-transparent backgrounds (`rgba(0,0,0,0.55)`) and explicit white icon colors. Active-state colors (mute, pause, info, burst, queue, favorite) are now set directly on the `ha-icon` element so they work correctly on all themes.
+
 ## v5.9.0 - 2026-04-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Configure via the visual editor ("Shared Queue ID" in the Image Options section) or in YAML as `shared_queue_id: "my_queue"`
 
 ### Fixed
+- **Cross-device sync: manual navigation on the leader card did not update other browsers** (`shared_queue_id` feature): When Card A received any HA sync event from Card B, `_crossDeviceFollowerUntil` was set to `now + 30s` on Card A, blocking the HA debounce write for 30 seconds. `_forceClaimLeadership()` only cleared this flag when displacing a *different* local leader — when Card A was already the window-local leader it returned early, leaving the follower flag active. Any manual navigation on Card A wrote to `localStorage`/`CustomEvent` (same-browser) but the HA service call was suppressed, so Card B on the other browser never received it. Fixed by moving all follower-state resets (`_crossDeviceFollowerUntil`, `_crossDeviceProviderFetchUntil`, `_suppressSyncWriteUntil`, and pending timer cancellation) before the early-return guard so they always execute on any manual navigation regardless of whether local window leadership changes.
+
 - **Action button colors washed out on light and frosted-glass themes**: Button backgrounds were derived from `--rgb-card-background-color`, which resolves to near-white on many light themes, making icons invisible. Fixed by using hardcoded dark semi-transparent backgrounds (`rgba(0,0,0,0.55)`) and explicit white icon colors. Active-state colors (mute, pause, info, burst, queue, favorite) are now set directly on the `ha-icon` element so they work correctly on all themes.
 
 ## v5.9.0 - 2026-04-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,25 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## v5.10.0 - 2026-04-22
 
 ### Added
-- **Local vs Group Pause** (`shared_queue_id` feature): Pause behavior now distinguishes between pausing just the current card and pausing an entire sync group
-  - **Short press** on the pause button: **local pause only** — the card stops advancing but does not broadcast to peers. Locally paused cards silently ignore incoming sync navigation events; manual back/forward still works but does not broadcast or steal sync leadership
-  - **Long press** (hold 600 ms) on the pause button: **group pause** — broadcasts a pause event to all cards sharing the same `shared_queue_id`. All cards in the group stop advancing simultaneously
-  - **Resuming from a group pause**: broadcasts a resume event to all peers, re-synchronizing the group
-  - Long-pressing the pause button no longer accidentally triggers the card-level `hold_action`
-  - Replaces the previous behavior where any pause was globally broadcast to all sync group members
-
-- **Same-Window Leader Election** (`shared_queue_id` feature): When two or more cards on the same browser tab share a `shared_queue_id`, exactly one card drives the slideshow timer at a time. The others suppress their timers and follow the leader via the local `CustomEvent` bus. Manually navigating on any card immediately promotes it to leader. When a leader is destroyed (card removed or navigated away), the next card claims leadership automatically via a vacancy event.
-
-- **Shared Queue** (`shared_queue_id`): Multiple cards across any number of views — or across different devices and browsers — share a single navigation queue and stay in lock-step. Set the same `shared_queue_id` string on every participating card and they will always show the same image with a shared navigation history so back/forward work everywhere. Three complementary transports keep all cards in sync:
-  - **Same-window**: `CustomEvent` bus for zero-latency sync between cards on the same browser tab
+- **Cross-Device Slideshow Sync** (`shared_queue_id`): Multiple cards across any number of views, devices, and browsers share a single navigation queue and stay in lock-step. Set the same `shared_queue_id` on every participating card and they will always show the same image with a shared navigation history so back/forward work everywhere. Three complementary transports keep all cards in sync:
+  - **Same-window**: `CustomEvent` bus for zero-latency sync between cards on the same browser tab. Exactly one card drives the slideshow timer — others suppress theirs and follow the leader. Manual navigation instantly promotes that card to leader; when a leader is destroyed the next card claims leadership automatically via a vacancy event
   - **Cross-view persistence**: `localStorage` so switching to a different dashboard view immediately shows the current image
-  - **Cross-device**: When the `media_index` source is active, the card writes sync state through the `media_index.update_sync_state` service and listens for the resulting `media_index_sync_state` HA event — keeping wall tablets, mobile phones, and any other device in sync in real time
-  - Pause/resume syncs reliably across all devices: only explicit user pause actions propagate; automatic navigation advances never accidentally override a peer's pause state
-  - The current image's metadata (date, location, camera) is included in every sync payload so receiving cards display the correct information without making their own service calls
-  - Configure via the visual editor ("Shared Queue ID" in the Image Options section) or in YAML as `shared_queue_id: "my_queue"`
+  - **Cross-device**: When the `media_index` source is active, sync state is written through `media_index.update_sync_state` and delivered via the `media_index.sync_updated` HA event, keeping wall tablets, phones, and any other browser in sync in real time
+  - **Pause sync**: Short-press pause stops only the local card; long-press (600 ms) broadcasts a group pause or resume to all peers. Locally paused cards silently ignore incoming navigation events. Only explicit user pause actions propagate — automatic advances never override a peer's pause state
+  - Current image metadata (date, location, camera) is included in every sync payload so receiving cards display the correct information without extra service calls
+  - Configure via the visual editor ("Shared Queue ID" in Image Options) or YAML: `shared_queue_id: "my_queue"`
 
 ### Fixed
-- **Cross-device sync: manual navigation on the leader card did not update other browsers** (`shared_queue_id` feature): When Card A received any HA sync event from Card B, `_crossDeviceFollowerUntil` was set to `now + 30s` on Card A, blocking the HA debounce write for 30 seconds. `_forceClaimLeadership()` only cleared this flag when displacing a *different* local leader — when Card A was already the window-local leader it returned early, leaving the follower flag active. Any manual navigation on Card A wrote to `localStorage`/`CustomEvent` (same-browser) but the HA service call was suppressed, so Card B on the other browser never received it. Fixed by moving all follower-state resets (`_crossDeviceFollowerUntil`, `_crossDeviceProviderFetchUntil`, `_suppressSyncWriteUntil`, and pending timer cancellation) before the early-return guard so they always execute on any manual navigation regardless of whether local window leadership changes.
+- **Action buttons in single-media mode**: The action button strip is now context-aware when `media_source_type: single_media` is configured
+  - **Pause button hidden**: There is no auto-advance slideshow timer in single-media mode, so the pause button is no longer shown
+  - **Mute button follows actual file type**: The mute button now shows or hides based on the file extension of the currently displayed item rather than the configured `media_type` filter — so it correctly appears for videos and is hidden for images even when `media_type` is not explicitly set
 
 - **Action button colors washed out on light and frosted-glass themes**: Button backgrounds were derived from `--rgb-card-background-color`, which resolves to near-white on many light themes, making icons invisible. Fixed by using hardcoded dark semi-transparent backgrounds (`rgba(0,0,0,0.55)`) and explicit white icon colors. Active-state colors (mute, pause, info, burst, queue, favorite) are now set directly on the `ha-icon` element so they work correctly on all themes.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## v5.10.0 - 2026-04-22
 
 ### Added
+- **Local vs Group Pause** (`shared_queue_id` feature): Pause behavior now distinguishes between pausing just the current card and pausing an entire sync group
+  - **Short press** on the pause button: **local pause only** — the card stops advancing but does not broadcast to peers. Locally paused cards silently ignore incoming sync navigation events; manual back/forward still works but does not broadcast or steal sync leadership
+  - **Long press** (hold 600 ms) on the pause button: **group pause** — broadcasts a pause event to all cards sharing the same `shared_queue_id`. All cards in the group stop advancing simultaneously
+  - **Resuming from a group pause**: broadcasts a resume event to all peers, re-synchronizing the group
+  - Long-pressing the pause button no longer accidentally triggers the card-level `hold_action`
+  - Replaces the previous behavior where any pause was globally broadcast to all sync group members
+
+- **Same-Window Leader Election** (`shared_queue_id` feature): When two or more cards on the same browser tab share a `shared_queue_id`, exactly one card drives the slideshow timer at a time. The others suppress their timers and follow the leader via the local `CustomEvent` bus. Manually navigating on any card immediately promotes it to leader. When a leader is destroyed (card removed or navigated away), the next card claims leadership automatically via a vacancy event.
+
 - **Shared Queue** (`shared_queue_id`): Multiple cards across any number of views — or across different devices and browsers — share a single navigation queue and stay in lock-step. Set the same `shared_queue_id` string on every participating card and they will always show the same image with a shared navigation history so back/forward work everywhere. Three complementary transports keep all cards in sync:
   - **Same-window**: `CustomEvent` bus for zero-latency sync between cards on the same browser tab
   - **Cross-view persistence**: `localStorage` so switching to a different dashboard view immediately shows the current image

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ It is highly recommended you also install the [Media Index Integration](https://
 - 🏷️ **Metadata Display**: Selectively overlay key metadata elements - EXIF date, time and location, and folder and file name
 ### **Intelligent Navigation**
 - ⏸️ **Manual Queue Navigation**: Manually pause/resume, advance forward and back in a queue.
-- 📋 **Queue Preview Panel**: View upcoming and previous items in your slideshow queue with thumbnail navigation
+- � **Cross-Device Shared Queue** (`shared_queue_id`): Keep multiple cards — on different views, tablets, phones, or any device — locked to the same image with shared history and pause state. Same-window sync is instant via browser events; cross-browser and cross-device sync uses Home Assistant events (requires Media Index).
+- �📋 **Queue Preview Panel**: View upcoming and previous items in your slideshow queue with thumbnail navigation
 - ⌨️ **Keyboard Shortcuts**: Arrow keys, space, and more
 - 👆 **Interactive Actions**: Tap, hold, and double-tap customization with optional custom confirmation messages
 ### **Media Discovery Features** (requires Media Index)

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ It is highly recommended you also install the [Media Index Integration](https://
 - 🏷️ **Metadata Display**: Selectively overlay key metadata elements - EXIF date, time and location, and folder and file name
 ### **Intelligent Navigation**
 - ⏸️ **Manual Queue Navigation**: Manually pause/resume, advance forward and back in a queue.
-- � **Cross-Device Shared Queue** (`shared_queue_id`): Keep multiple cards — on different views, tablets, phones, or any device — locked to the same image with shared history and pause state. Same-window sync is instant via browser events; cross-browser and cross-device sync uses Home Assistant events (requires Media Index).
-- �📋 **Queue Preview Panel**: View upcoming and previous items in your slideshow queue with thumbnail navigation
+- 🔗 **Cross-Device Shared Queue** (`shared_queue_id`): Keep multiple cards — on different views, tablets, phones, or any device — locked to the same image with shared history and pause state. Same-window sync is instant via browser events; cross-browser and cross-device sync uses Home Assistant events (requires Media Index).
+- 📋 **Queue Preview Panel**: View upcoming and previous items in your slideshow queue with thumbnail navigation
 - ⌨️ **Keyboard Shortcuts**: Arrow keys, space, and more
 - 👆 **Interactive Actions**: Tap, hold, and double-tap customization with optional custom confirmation messages
 ### **Media Discovery Features** (requires Media Index)

--- a/ha-media-card.js
+++ b/ha-media-card.js
@@ -8813,6 +8813,12 @@ class MediaCard extends LitElement {
       if (data.isPaused) { this._pauseTimer(); } else { this._resumeTimer(); }
     }
 
+    // If this card is still paused after processing the intent, do not follow navigation
+    // from peers. The user intentionally paused this card; auto-advance from other running
+    // cards should not override that. A resume (pauseIntent=true, isPaused=false) will have
+    // already cleared _isPaused above, so the card resumes and still navigates.
+    if (this._isPaused) return;
+
     // Skip navigation if we are already showing this path OR already navigating to it.
     // The _pendingMediaPath check prevents duplicate navigation when the same update
     // arrives via multiple transports (CustomEvent then HA event ~500ms later) before

--- a/ha-media-card.js
+++ b/ha-media-card.js
@@ -8688,13 +8688,17 @@ class MediaCard extends LitElement {
     this._storageEventHandler = this._onStorageEvent.bind(this);
     window.addEventListener('storage', this._storageEventHandler);
 
-    // Cross-device: subscribe to HA bus event fired by media_index.update_sync_state
+    // Cross-device: subscribe to HA bus event fired by media_index.update_sync_state.
+    // We use a custom WebSocket command (media_index/subscribe_sync) registered by the
+    // integration rather than the generic subscribe_events command, because subscribe_events
+    // requires admin for custom integration events — non-admin dashboard users would be
+    // refused. The custom command has its own handler that allows any authenticated user.
     if (this._hasCrossDeviceSync()) {
-      this._haSyncUnsubscribe = this.hass.connection.subscribeEvents(
-        (event) => this._onHaSyncEvent(event),
-        'media_index.sync_updated'
+      this._haSyncUnsubscribe = this.hass.connection.subscribeMessage(
+        (msg) => this._onHaSyncEvent({ data: msg }),
+        { type: 'media_index/subscribe_sync', sync_group: id }
       ).catch(e => {
-        this._log('⚠️ Failed to subscribe to media_index.sync_updated:', e);
+        this._log('⚠️ Failed to subscribe to media_index sync events:', e);
         this._haSyncUnsubscribe = null;
       });
     }

--- a/ha-media-card.js
+++ b/ha-media-card.js
@@ -4911,16 +4911,11 @@ class MediaCard extends LitElement {
       this._setupAutoRefresh();
     }
 
-    // Shared queue: listen for navigation events from other card instances
-    if (this.config?.shared_queue_id) {
-      this._storageEventHandler = this._onStorageEvent.bind(this);
-      window.addEventListener('storage', this._storageEventHandler);
-      this._queueSyncEventHandler = this._onQueueSyncEvent.bind(this);
-      window.addEventListener('ha-media-card-sync', this._queueSyncEventHandler);
-    }
+    // Shared queue: register event listeners (cross-device HA events + same-device)
+    this._subscribeToSyncEvents();
 
-    // Shared queue: if reconnecting (provider already exists), sync from localStorage
-    // to pick up everything the other card navigated while this card was hidden
+    // Shared queue: if reconnecting (provider already exists), sync state from
+    // media-index or localStorage to pick up where the other card left off
     if (this.provider && this.config?.shared_queue_id) {
       this._syncFromSharedQueueOnReconnect();
     }
@@ -4934,15 +4929,8 @@ class MediaCard extends LitElement {
     // NEW: Cleanup kiosk mode monitoring
     this._cleanupKioskModeMonitoring();
     
-    // Shared queue: remove storage event listener
-    if (this._storageEventHandler) {
-      window.removeEventListener('storage', this._storageEventHandler);
-      this._storageEventHandler = null;
-    }
-    if (this._queueSyncEventHandler) {
-      window.removeEventListener('ha-media-card-sync', this._queueSyncEventHandler);
-      this._queueSyncEventHandler = null;
-    }
+    // Shared queue: remove all event listeners and cancel pending debounced write
+    this._unsubscribeFromSyncEvents();
     
     // V5.6: Cleanup viewport height observer
     this._cleanupDynamicViewportHeight();
@@ -5214,7 +5202,11 @@ class MediaCard extends LitElement {
     if (this._debugMode || window.location.hostname === 'localhost') {
       // Prefix all logs with card ID for debugging
       const prefix = `[${this._cardId}]`;
-      const message = args.join(' ');
+      // Strip auth tokens (e.g. Synology authSig) so logs stay readable when pasting
+      const sanitizedArgs = args.map(a =>
+        typeof a === 'string' ? a.replace(/([?&])authSig=[^&\s]*/gi, '$1authSig=[…]') : a
+      );
+      const message = sanitizedArgs.join(' ');
       
       // Throttle certain frequent messages to avoid spam
       const throttlePatterns = [
@@ -5239,7 +5231,7 @@ class MediaCard extends LitElement {
         this._lastLogTime[message] = now;
       }
       
-      console.log(prefix, ...args);
+      console.log(prefix, ...sanitizedArgs);
     }
   }
 
@@ -5758,7 +5750,7 @@ class MediaCard extends LitElement {
       if (success) {
         // Shared queue takes priority over local history when configured — it holds the
         // freshest cross-card state (what the other card was showing when this view was hidden).
-        const restoredFromShared = this._tryRestoreFromSharedQueue();
+        const restoredFromShared = await this._tryRestoreFromSharedQueue();
 
         if (restoredFromShared) {
           // Queue and index already set — jump directly to the saved item
@@ -6052,6 +6044,9 @@ class MediaCard extends LitElement {
           this._pendingNavigationIndex = 0;
         } else {
           this._log('Navigation queue exhausted, loading from provider');
+          // Capture generation before any awaits so we can detect if a sync event
+          // arrived from another card while we were waiting for the provider.
+          const _syncGenBefore = this._syncNavGeneration || 0;
           let item = await this.provider.getNext();
         
           if (item) {
@@ -6121,6 +6116,16 @@ class MediaCard extends LitElement {
                 // forward to the new item, not staying at the current position
                 nextIndex = this.navigationQueue.length - 1;
               }
+
+              // Sync mode: if another card already broadcast a new item while we were awaiting
+              // the provider (same-window CustomEvent fires mid-await), follow that card instead.
+              if ((this._syncNavGeneration || 0) > _syncGenBefore) {
+                this._log('🔗 Another synced card broadcast first — following sync navigation, discarding locally-fetched item');
+                return;
+              }
+              // We are the "first" card — broadcast our new item immediately so other
+              // same-window cards adopt it synchronously before they exit their own awaits.
+              this._earlyBroadcastSyncState(nextIndex);
             }
           } else {
             // No more items available from provider, wrap to beginning with fresh query
@@ -8455,102 +8460,296 @@ class MediaCard extends LitElement {
     }
   }
 
-  // Shared Queue: write current queue state to localStorage and broadcast to same-window instances
-  _writeSharedQueueState() {
+  // ─── Shared Queue ──────────────────────────────────────────────────────────
+  // Two transport layers, selected automatically:
+  //   • Cross-device (media-index configured): service calls + HA websocket events
+  //   • Single-device fallback: localStorage + window CustomEvent
+
+  // Return the media_index entity_id configured on this card, or null.
+  _getMediaIndexEntityId() {
+    return this.config?.media_index?.entity_id || null;
+  }
+
+  // Is cross-device sync available?
+  _hasCrossDeviceSync() {
+    return !!(this.config?.shared_queue_id && this._getMediaIndexEntityId() && this.hass);
+  }
+
+  // ── Write path ──────────────────────────────────────────────────────────────
+  // Called after every navigation commit. Debounced to avoid hammering the service.
+  // pauseIntent=true ONLY for user-initiated pause/resume actions — navigation writes
+  // must NOT set it, otherwise Device B's navigation will overwrite Device A's local
+  // pause state.
+  _writeSharedQueueState(pauseIntent = false) {
     const id = this.config?.shared_queue_id;
     if (!id || !this.navigationQueue?.length) return;
+
+    // Echo-prevention: skip the write that would bounce an incoming navigation sync
+    // back to the sender. BUT always allow explicit pause/resume writes through so
+    // that a pause arriving simultaneously with a navigation doesn't get swallowed.
+    if (this._suppressSyncWrite && !pauseIntent) {
+      this._suppressSyncWrite = false;
+      return;
+    }
+    this._suppressSyncWrite = false;
+
+    // Always write localStorage for instant same-device sync
     try {
       const data = {
         queue: this.navigationQueue.map(item => item.media_content_id),
         currentIndex: this.navigationIndex,
+        // Include metadata for the current item so receiving cards can display it
+        // immediately without needing a separate media-index fetch.
+        currentMetadata: this._currentMetadata || this._pendingMetadata || null,
+        isPaused: this._isPaused,
+        pauseIntent,
         updatedAt: Date.now(),
-        sourceCardId: this._cardId  // so listeners can ignore their own writes
+        sourceCardId: this._cardId,
       };
       localStorage.setItem(`ha-media-card:${id}`, JSON.stringify(data));
-      // Also broadcast within same window (storage event doesn't fire for same-window writes)
+      // Broadcast within same window (storage event doesn't fire for same-window writes)
       window.dispatchEvent(new CustomEvent('ha-media-card-sync', { detail: { sharedQueueId: id, ...data } }));
-    } catch (_e) {
-      // localStorage may be unavailable in some environments
+    } catch (_e) {}
+
+    // Cross-device: debounced service call.
+    // Accumulate pauseIntent across debounce resets so that a pause write that arrives
+    // just before a navigation write doesn't silently lose the intent.
+    if (this._hasCrossDeviceSync()) {
+      this._pendingSyncPauseIntent = (this._pendingSyncPauseIntent || false) || pauseIntent;
+      if (this._syncWriteTimer) clearTimeout(this._syncWriteTimer);
+      this._syncWriteTimer = setTimeout(() => {
+        this._syncWriteTimer = null;
+        const intent = this._pendingSyncPauseIntent || false;
+        this._pendingSyncPauseIntent = false;
+        this._writeSharedQueueStateToMediaIndex(intent);
+      }, 500);
     }
   }
 
-  // Shared Queue: called on reconnect (provider already exists) to sync queue state
-  // from localStorage so this card picks up where the other card left off
-  _syncFromSharedQueueOnReconnect() {
+  async _writeSharedQueueStateToMediaIndex(pauseIntent = false) {
     const id = this.config?.shared_queue_id;
-    if (!id) return;
+    if (!id || !this.navigationQueue?.length) return;
     try {
-      const raw = localStorage.getItem(`ha-media-card:${id}`);
-      if (!raw) return;
-      const data = JSON.parse(raw);
-      if (!Array.isArray(data.queue) || !data.queue.length) return;
-      const newIndex = Math.min(
-        typeof data.currentIndex === 'number' ? data.currentIndex : 0,
-        data.queue.length - 1
-      );
-      const newPath = data.queue[newIndex];
-      // Always restore the full queue so back-navigation history is preserved
-      this.navigationQueue = data.queue.map(mediaId => ({
-        media_content_id: mediaId,
-        media_content_type: MediaUtils.detectFileType(mediaId) || 'image',
-        title: mediaId.split('/').pop() || mediaId,
-        metadata: null
-      }));
-      this.navigationIndex = newIndex;
-      this._log(`🔗 Shared queue synced on reconnect: ${this.navigationQueue.length} items, index ${newIndex}`);
-      // Navigate to the current image if it differs from what we were last showing
-      if (newPath !== this._currentMediaPath) {
-        const item = this.navigationQueue[newIndex];
-        this.currentMedia = item;
-        this._pendingNavigationIndex = newIndex;
-        this._pendingMediaPath = newPath;
-        this._pendingMetadata = null;
-        this._resolveMediaUrl();
-        this.requestUpdate();
-      }
-    } catch (_e) {}
+      const entityId = this._getMediaIndexEntityId();
+      const queue = this.navigationQueue.map(item => item.media_content_id);
+      await this.hass.connection.sendMessagePromise({
+        type: 'call_service',
+        domain: 'media_index',
+        service: 'update_sync_state',
+        service_data: {
+          sync_group: id,
+          queue,
+          current_index: this.navigationIndex,
+          is_paused: this._isPaused,
+          pause_intent: pauseIntent,
+          source_card_id: this._cardId,
+          current_metadata: JSON.stringify(this._currentMetadata || this._pendingMetadata || null),
+        },
+        target: { entity_id: entityId },
+      });
+      this._log(`🔗 Sync state written to media_index for group '${id}'`);
+    } catch (e) {
+      this._log('⚠️ Failed to write shared queue to media_index:', e);
+    }
   }
 
-  // Shared Queue: restore queue from localStorage on load
-  // Returns true if queue was restored (caller should skip normal provider init)
-  _tryRestoreFromSharedQueue() {
+  // ── Read path (first load) ──────────────────────────────────────────────────
+  // Returns true and populates navigationQueue/navigationIndex if state was found.
+  async _tryRestoreFromSharedQueue() {
     const id = this.config?.shared_queue_id;
     if (!id) return false;
+
+    // Cross-device: fetch from media-index (authoritative, any device may have written it)
+    if (this._hasCrossDeviceSync()) {
+      try {
+        const entityId = this._getMediaIndexEntityId();
+        const resp = await this.hass.connection.sendMessagePromise({
+          type: 'call_service',
+          domain: 'media_index',
+          service: 'get_sync_state',
+          service_data: { sync_group: id },
+          target: { entity_id: entityId },
+          return_response: true,
+        });
+        const data = resp?.response;
+        if (data?.found && Array.isArray(data.queue) && data.queue.length) {
+          return this._applyRestoredState(data.queue, data.current_index);
+        }
+      } catch (e) {
+        this._log('⚠️ Could not fetch sync state from media_index, falling back to localStorage:', e);
+      }
+    }
+
+    // Single-device fallback: localStorage
     try {
       const raw = localStorage.getItem(`ha-media-card:${id}`);
       if (!raw) return false;
       const data = JSON.parse(raw);
       if (!Array.isArray(data.queue) || !data.queue.length) return false;
-      this.navigationQueue = data.queue.map(mediaId => ({
-        media_content_id: mediaId,
-        media_content_type: MediaUtils.detectFileType(mediaId) || 'image',
-        title: mediaId.split('/').pop() || mediaId,
-        metadata: null
-      }));
-      this.navigationIndex = Math.min(
-        typeof data.currentIndex === 'number' ? data.currentIndex : 0,
-        this.navigationQueue.length - 1
-      );
-      this._log(`🔗 Shared queue restored: ${this.navigationQueue.length} items, index ${this.navigationIndex}`);
-      return true;
+      return this._applyRestoredState(data.queue, data.currentIndex);
     } catch (_e) {
       return false;
     }
   }
 
-  // Shared Queue: handle storage events from OTHER browser tabs/windows
+  // ── Read path (reconnect) ───────────────────────────────────────────────────
+  async _syncFromSharedQueueOnReconnect() {
+    const id = this.config?.shared_queue_id;
+    if (!id) return;
+
+    let queue = null, currentIndex = 0;
+
+    // Cross-device: fetch from media-index
+    if (this._hasCrossDeviceSync()) {
+      try {
+        const entityId = this._getMediaIndexEntityId();
+        const resp = await this.hass.connection.sendMessagePromise({
+          type: 'call_service',
+          domain: 'media_index',
+          service: 'get_sync_state',
+          service_data: { sync_group: id },
+          target: { entity_id: entityId },
+          return_response: true,
+        });
+        const data = resp?.response;
+        if (data?.found && Array.isArray(data.queue) && data.queue.length) {
+          queue = data.queue;
+          currentIndex = typeof data.current_index === 'number' ? data.current_index : 0;
+        }
+      } catch (e) {
+        this._log('⚠️ Could not fetch sync state from media_index for reconnect:', e);
+      }
+    }
+
+    // Fallback: localStorage
+    if (!queue) {
+      try {
+        const raw = localStorage.getItem(`ha-media-card:${id}`);
+        if (raw) {
+          const data = JSON.parse(raw);
+          if (Array.isArray(data.queue) && data.queue.length) {
+            queue = data.queue;
+            currentIndex = typeof data.currentIndex === 'number' ? data.currentIndex : 0;
+          }
+        }
+      } catch (_e) {}
+    }
+
+    if (!queue) return;
+    const newIndex = Math.min(currentIndex, queue.length - 1);
+    const newPath = queue[newIndex];
+    this.navigationQueue = queue.map(mediaId => ({
+      media_content_id: mediaId,
+      media_content_type: MediaUtils.detectFileType(mediaId) || 'image',
+      title: mediaId.split('/').pop() || mediaId,
+      metadata: null,
+    }));
+    this.navigationIndex = newIndex;
+    this._log(`🔗 Shared queue synced on reconnect: ${this.navigationQueue.length} items, index ${newIndex}`);
+    if (newPath !== this._currentMediaPath) {
+      const item = this.navigationQueue[newIndex];
+      this.currentMedia = item;
+      this._pendingNavigationIndex = newIndex;
+      this._pendingMediaPath = newPath;
+      this._pendingMetadata = null;
+      this._resolveMediaUrl();
+      this.requestUpdate();
+    }
+  }
+
+  // ── Shared helper ───────────────────────────────────────────────────────────
+  _applyRestoredState(queue, rawIndex) {
+    this.navigationQueue = queue.map(mediaId => ({
+      media_content_id: mediaId,
+      media_content_type: MediaUtils.detectFileType(mediaId) || 'image',
+      title: mediaId.split('/').pop() || mediaId,
+      metadata: null,
+    }));
+    this.navigationIndex = Math.min(
+      typeof rawIndex === 'number' ? rawIndex : 0,
+      this.navigationQueue.length - 1
+    );
+    this._log(`🔗 Shared queue restored: ${this.navigationQueue.length} items, index ${this.navigationIndex}`);
+    return true;
+  }
+
+  // ── Event listeners ─────────────────────────────────────────────────────────
+  // Subscribe to HA websocket events (cross-device) and window CustomEvent (same-device).
+  _subscribeToSyncEvents() {
+    const id = this.config?.shared_queue_id;
+    if (!id) return;
+
+    // Same-window CustomEvent (instant, no round-trip)
+    this._queueSyncEventHandler = this._onQueueSyncEvent.bind(this);
+    window.addEventListener('ha-media-card-sync', this._queueSyncEventHandler);
+
+    // Same-device cross-tab via storage event
+    this._storageEventHandler = this._onStorageEvent.bind(this);
+    window.addEventListener('storage', this._storageEventHandler);
+
+    // Cross-device: subscribe to HA bus event fired by media_index.update_sync_state
+    if (this._hasCrossDeviceSync()) {
+      this._haSyncUnsubscribe = this.hass.connection.subscribeEvents(
+        (event) => this._onHaSyncEvent(event),
+        'media_index.sync_updated'
+      ).catch(e => {
+        this._log('⚠️ Failed to subscribe to media_index.sync_updated:', e);
+        this._haSyncUnsubscribe = null;
+      });
+    }
+  }
+
+  _unsubscribeFromSyncEvents() {
+    if (this._storageEventHandler) {
+      window.removeEventListener('storage', this._storageEventHandler);
+      this._storageEventHandler = null;
+    }
+    if (this._queueSyncEventHandler) {
+      window.removeEventListener('ha-media-card-sync', this._queueSyncEventHandler);
+      this._queueSyncEventHandler = null;
+    }
+    if (this._haSyncUnsubscribe) {
+      // subscribeEvents returns a Promise<unsubscribe fn>; handle both cases
+      Promise.resolve(this._haSyncUnsubscribe).then(unsub => { if (unsub) unsub(); }).catch(() => {});
+      this._haSyncUnsubscribe = null;
+    }
+    if (this._syncWriteTimer) {
+      clearTimeout(this._syncWriteTimer);
+      this._syncWriteTimer = null;
+    }
+  }
+
+  // HA websocket event from media_index (cross-device)
+  _onHaSyncEvent(event) {
+    const id = this.config?.shared_queue_id;
+    const data = event.data;
+    if (!id || data?.sync_group !== id) return;
+    // Ignore events we ourselves wrote (media_index echoes back to all subscribers)
+    if (data?.source_card_id === this._cardId) return;
+    let currentMetadata = null;
+    if (data.current_metadata) {
+      try { currentMetadata = JSON.parse(data.current_metadata); } catch (_e) {}
+    }
+    this._applySharedQueueUpdate({
+      queue: data.queue,
+      currentIndex: data.current_index,
+      currentMetadata,
+      isPaused: data.is_paused,
+      pauseIntent: data.pause_intent,
+    });
+  }
+
+  // storage event (cross-tab, same device)
   _onStorageEvent(event) {
     const id = this.config?.shared_queue_id;
     if (!id || event.key !== `ha-media-card:${id}` || !event.newValue) return;
     try {
       const data = JSON.parse(event.newValue);
       this._applySharedQueueUpdate(data);
-    } catch (_e) {
-      // ignore malformed data
-    }
+    } catch (_e) {}
   }
 
-  // Shared Queue: handle CustomEvents from other card instances in the same window
+  // window CustomEvent (same window, instant)
   _onQueueSyncEvent(event) {
     const id = this.config?.shared_queue_id;
     if (!id || event.detail?.sharedQueueId !== id) return;
@@ -8558,7 +8757,26 @@ class MediaCard extends LitElement {
     this._applySharedQueueUpdate(event.detail);
   }
 
-  // Shared Queue: shared logic for applying an incoming queue update
+  // Broadcast the new queue state (with a specific index) without waiting for image load.
+  // Used when the local provider returns a new item so that same-window cards receive
+  // it synchronously (before their own provider awaits complete) and follow along.
+  _earlyBroadcastSyncState(nextIndex) {
+    const id = this.config?.shared_queue_id;
+    if (!id) return;
+    try {
+      const data = {
+        queue: this.navigationQueue.map(qi => qi.media_content_id),
+        currentIndex: nextIndex,
+        isPaused: this._isPaused,
+        updatedAt: Date.now(),
+        sourceCardId: this._cardId,
+      };
+      localStorage.setItem(`ha-media-card:${id}`, JSON.stringify(data));
+      window.dispatchEvent(new CustomEvent('ha-media-card-sync', { detail: { sharedQueueId: id, ...data } }));
+    } catch (_e) {}
+  }
+
+  // Apply an incoming queue update from any transport
   _applySharedQueueUpdate(data) {
     if (!Array.isArray(data.queue) || !data.queue.length) return;
     const newIndex = Math.min(
@@ -8566,23 +8784,74 @@ class MediaCard extends LitElement {
       data.queue.length - 1
     );
     const newPath = data.queue[newIndex];
-    if (newPath === this._currentMediaPath) return; // already showing this
+
+    // Increment generation counter so any _loadNext() suspended in an await will
+    // see that a sync event took priority and should not overwrite our navigation.
+    this._syncNavGeneration = (this._syncNavGeneration || 0) + 1;
+
+    // Apply pause state ONLY when the sender explicitly toggled it (pauseIntent).
+    // Navigation syncs carry the sender's current isPaused as context (for new devices
+    // joining the group) but must NOT overwrite the local pause state — otherwise
+    // Device B playing and Device A paused leads to Device B's navigation writes
+    // continuously unpausing Device A.
+    if (data.pauseIntent === true && typeof data.isPaused === 'boolean' && data.isPaused !== this._isPaused) {
+      this._setPauseState(data.isPaused);
+      if (data.isPaused) { this._pauseTimer(); } else { this._resumeTimer(); }
+    }
+
+    // Skip navigation if we are already showing this path OR already navigating to it.
+    // The _pendingMediaPath check prevents duplicate navigation when the same update
+    // arrives via multiple transports (CustomEvent then HA event ~500ms later) before
+    // the image has fully loaded and _currentMediaPath has been committed.
+    // HOWEVER: a second broadcast for the same path may carry metadata that the first
+    // (early) broadcast lacked — apply it even if we skip navigation.
+    if (newPath === this._currentMediaPath || newPath === this._pendingMediaPath) {
+      if (data.currentMetadata) {
+        if (this._pendingMediaPath !== null) {
+          // Still loading — merge into pending so it applies when image loads
+          this._pendingMetadata = { ...(this._pendingMetadata || {}), ...data.currentMetadata };
+        } else {
+          // Already showing — apply directly and re-render
+          this._currentMetadata = { ...(this._currentMetadata || {}), ...data.currentMetadata };
+          this.requestUpdate();
+        }
+      }
+      return;
+    }
     this._log(`🔗 Shared queue sync: navigating to index ${newIndex}`);
+
+    // Reset the auto-advance timer immediately. Without this, the old timer (which may
+    // be only seconds from expiring) would fire before the incoming image loads, call
+    // _loadNext(), exhaust the queue, fetch a DIFFERENT item and broadcast it — causing
+    // a cascade where each of the N cards adds a new item in rapid succession.
+    // _setupAutoRefresh clears the old interval and starts a fresh full-duration one.
+    if (!this._isPaused) {
+      this._setupAutoRefresh();
+    }
     this.navigationQueue = data.queue.map(mediaId => ({
       media_content_id: mediaId,
       media_content_type: MediaUtils.detectFileType(mediaId) || 'image',
       title: mediaId.split('/').pop() || mediaId,
-      metadata: null
+      metadata: null,
     }));
     this.navigationIndex = newIndex;
     const item = this.navigationQueue[newIndex];
     this.currentMedia = item;
     this._pendingNavigationIndex = newIndex;
     this._pendingMediaPath = newPath;
-    this._pendingMetadata = null;
+    // Use metadata from the sender if provided — avoids a round-trip fetch and
+    // works even when this card has no media-index configured.
+    this._pendingMetadata = data.currentMetadata || null;
+    // Suppress the outgoing write that would otherwise echo this event back
+    this._suppressSyncWrite = true;
     this._resolveMediaUrl();
     this.requestUpdate();
+    // For media-index cards: kick off a background fetch to get fresher/fuller
+    // metadata (sender may have had stale data too). No-op for non-media-index cards.
+    this._refreshMetadata().catch(err => this._log('⚠️ Sync metadata refresh failed:', err));
   }
+
+  // ── End Shared Queue ────────────────────────────────────────────────────────
 
   // V4: Keyboard navigation handler
   _handleKeyDown(e) {
@@ -8620,7 +8889,8 @@ class MediaCard extends LitElement {
       } else {
         this._setupAutoRefresh();
       }
-      
+      // Broadcast pause state to all synced cards
+      this._writeSharedQueueState(true);
       this.requestUpdate();
     }
   }
@@ -8641,6 +8911,8 @@ class MediaCard extends LitElement {
     } else {
       this._resumeTimer();
     }
+    // Broadcast pause state to all synced cards
+    this._writeSharedQueueState(true);
   }
   
   // V4: Pause state management (copied from ha-media-card.js)
@@ -8903,7 +9175,7 @@ class MediaCard extends LitElement {
       
       // Priority 3: Filesystem date as last fallback
       if (!date && metadata.date) {
-        date = metadata.date;
+        date = (metadata.date instanceof Date) ? metadata.date : new Date(metadata.date);
       }
       
       if (date && !isNaN(date.getTime())) {
@@ -10317,6 +10589,8 @@ class MediaCard extends LitElement {
       this._resumeTimer();
       this._log('▶️ RESUMED slideshow - timer restarted');
     }
+    // Broadcast pause state to all synced cards
+    this._writeSharedQueueState(true);
   }
   
   // Handle debug button click - toggle debug mode dynamically

--- a/ha-media-card.js
+++ b/ha-media-card.js
@@ -1,5 +1,5 @@
 /** 
- * Media Card v5.9.0
+ * Media Card v5.10.0
  */
 
 // Async wrapper for dynamic Lit loading (supports offline mode)
@@ -4910,6 +4910,20 @@ class MediaCard extends LitElement {
       this._log('🔄 Reconnected - restarting auto-refresh timer');
       this._setupAutoRefresh();
     }
+
+    // Shared queue: listen for navigation events from other card instances
+    if (this.config?.shared_queue_id) {
+      this._storageEventHandler = this._onStorageEvent.bind(this);
+      window.addEventListener('storage', this._storageEventHandler);
+      this._queueSyncEventHandler = this._onQueueSyncEvent.bind(this);
+      window.addEventListener('ha-media-card-sync', this._queueSyncEventHandler);
+    }
+
+    // Shared queue: if reconnecting (provider already exists), sync from localStorage
+    // to pick up everything the other card navigated while this card was hidden
+    if (this.provider && this.config?.shared_queue_id) {
+      this._syncFromSharedQueueOnReconnect();
+    }
   }
 
   disconnectedCallback() {
@@ -4919,6 +4933,16 @@ class MediaCard extends LitElement {
     
     // NEW: Cleanup kiosk mode monitoring
     this._cleanupKioskModeMonitoring();
+    
+    // Shared queue: remove storage event listener
+    if (this._storageEventHandler) {
+      window.removeEventListener('storage', this._storageEventHandler);
+      this._storageEventHandler = null;
+    }
+    if (this._queueSyncEventHandler) {
+      window.removeEventListener('ha-media-card-sync', this._queueSyncEventHandler);
+      this._queueSyncEventHandler = null;
+    }
     
     // V5.6: Cleanup viewport height observer
     this._cleanupDynamicViewportHeight();
@@ -5732,8 +5756,24 @@ class MediaCard extends LitElement {
       this._log('Provider initialized:', success);
       
       if (success) {
-        // V5 FIX: If we reconnected with history, restore current media from history
-        if (this.history.length > 0 && this.historyPosition >= 0) {
+        // Shared queue takes priority over local history when configured — it holds the
+        // freshest cross-card state (what the other card was showing when this view was hidden).
+        const restoredFromShared = this._tryRestoreFromSharedQueue();
+
+        if (restoredFromShared) {
+          // Queue and index already set — jump directly to the saved item
+          const item = this.navigationQueue[this.navigationIndex];
+          if (item) {
+            this.currentMedia = item;
+            this._pendingNavigationIndex = this.navigationIndex;
+            this._pendingMediaPath = item.media_content_id;
+            this._pendingMetadata = null;
+            await this._resolveMediaUrl();
+          } else {
+            await this._loadNext();
+          }
+        } else if (this.history.length > 0 && this.historyPosition >= 0) {
+          // V5 FIX: If we reconnected with history, restore current media from history
           this._log('🔄 Reconnected with history - loading media at position', this.historyPosition);
           const historyItem = this.history[this.historyPosition];
           if (historyItem) {
@@ -5745,10 +5785,8 @@ class MediaCard extends LitElement {
           }
         } else {
           this._log('Loading first media');
-          
           // V5.3: Smart pre-load - only for small collections
           await this._smartPreloadNavigationQueue();
-          
           await this._loadNext();
         }
         
@@ -7991,6 +8029,9 @@ class MediaCard extends LitElement {
       this._pendingMediaPath = null;
     }
     
+    // Shared queue: broadcast navigation to other cards with same shared_queue_id
+    this._writeSharedQueueState();
+    
     this.requestUpdate();
   }
 
@@ -8414,6 +8455,135 @@ class MediaCard extends LitElement {
     }
   }
 
+  // Shared Queue: write current queue state to localStorage and broadcast to same-window instances
+  _writeSharedQueueState() {
+    const id = this.config?.shared_queue_id;
+    if (!id || !this.navigationQueue?.length) return;
+    try {
+      const data = {
+        queue: this.navigationQueue.map(item => item.media_content_id),
+        currentIndex: this.navigationIndex,
+        updatedAt: Date.now(),
+        sourceCardId: this._cardId  // so listeners can ignore their own writes
+      };
+      localStorage.setItem(`ha-media-card:${id}`, JSON.stringify(data));
+      // Also broadcast within same window (storage event doesn't fire for same-window writes)
+      window.dispatchEvent(new CustomEvent('ha-media-card-sync', { detail: { sharedQueueId: id, ...data } }));
+    } catch (_e) {
+      // localStorage may be unavailable in some environments
+    }
+  }
+
+  // Shared Queue: called on reconnect (provider already exists) to sync queue state
+  // from localStorage so this card picks up where the other card left off
+  _syncFromSharedQueueOnReconnect() {
+    const id = this.config?.shared_queue_id;
+    if (!id) return;
+    try {
+      const raw = localStorage.getItem(`ha-media-card:${id}`);
+      if (!raw) return;
+      const data = JSON.parse(raw);
+      if (!Array.isArray(data.queue) || !data.queue.length) return;
+      const newIndex = Math.min(
+        typeof data.currentIndex === 'number' ? data.currentIndex : 0,
+        data.queue.length - 1
+      );
+      const newPath = data.queue[newIndex];
+      // Always restore the full queue so back-navigation history is preserved
+      this.navigationQueue = data.queue.map(mediaId => ({
+        media_content_id: mediaId,
+        media_content_type: MediaUtils.detectFileType(mediaId) || 'image',
+        title: mediaId.split('/').pop() || mediaId,
+        metadata: null
+      }));
+      this.navigationIndex = newIndex;
+      this._log(`🔗 Shared queue synced on reconnect: ${this.navigationQueue.length} items, index ${newIndex}`);
+      // Navigate to the current image if it differs from what we were last showing
+      if (newPath !== this._currentMediaPath) {
+        const item = this.navigationQueue[newIndex];
+        this.currentMedia = item;
+        this._pendingNavigationIndex = newIndex;
+        this._pendingMediaPath = newPath;
+        this._pendingMetadata = null;
+        this._resolveMediaUrl();
+        this.requestUpdate();
+      }
+    } catch (_e) {}
+  }
+
+  // Shared Queue: restore queue from localStorage on load
+  // Returns true if queue was restored (caller should skip normal provider init)
+  _tryRestoreFromSharedQueue() {
+    const id = this.config?.shared_queue_id;
+    if (!id) return false;
+    try {
+      const raw = localStorage.getItem(`ha-media-card:${id}`);
+      if (!raw) return false;
+      const data = JSON.parse(raw);
+      if (!Array.isArray(data.queue) || !data.queue.length) return false;
+      this.navigationQueue = data.queue.map(mediaId => ({
+        media_content_id: mediaId,
+        media_content_type: MediaUtils.detectFileType(mediaId) || 'image',
+        title: mediaId.split('/').pop() || mediaId,
+        metadata: null
+      }));
+      this.navigationIndex = Math.min(
+        typeof data.currentIndex === 'number' ? data.currentIndex : 0,
+        this.navigationQueue.length - 1
+      );
+      this._log(`🔗 Shared queue restored: ${this.navigationQueue.length} items, index ${this.navigationIndex}`);
+      return true;
+    } catch (_e) {
+      return false;
+    }
+  }
+
+  // Shared Queue: handle storage events from OTHER browser tabs/windows
+  _onStorageEvent(event) {
+    const id = this.config?.shared_queue_id;
+    if (!id || event.key !== `ha-media-card:${id}` || !event.newValue) return;
+    try {
+      const data = JSON.parse(event.newValue);
+      this._applySharedQueueUpdate(data);
+    } catch (_e) {
+      // ignore malformed data
+    }
+  }
+
+  // Shared Queue: handle CustomEvents from other card instances in the same window
+  _onQueueSyncEvent(event) {
+    const id = this.config?.shared_queue_id;
+    if (!id || event.detail?.sharedQueueId !== id) return;
+    if (event.detail?.sourceCardId === this._cardId) return; // ignore own writes
+    this._applySharedQueueUpdate(event.detail);
+  }
+
+  // Shared Queue: shared logic for applying an incoming queue update
+  _applySharedQueueUpdate(data) {
+    if (!Array.isArray(data.queue) || !data.queue.length) return;
+    const newIndex = Math.min(
+      typeof data.currentIndex === 'number' ? data.currentIndex : 0,
+      data.queue.length - 1
+    );
+    const newPath = data.queue[newIndex];
+    if (newPath === this._currentMediaPath) return; // already showing this
+    this._log(`🔗 Shared queue sync: navigating to index ${newIndex}`);
+    this.navigationQueue = data.queue.map(mediaId => ({
+      media_content_id: mediaId,
+      media_content_type: MediaUtils.detectFileType(mediaId) || 'image',
+      title: mediaId.split('/').pop() || mediaId,
+      metadata: null
+    }));
+    this.navigationIndex = newIndex;
+    const item = this.navigationQueue[newIndex];
+    this.currentMedia = item;
+    this._pendingNavigationIndex = newIndex;
+    this._pendingMediaPath = newPath;
+    this._pendingMetadata = null;
+    this._resolveMediaUrl();
+    this.requestUpdate();
+  }
+
   // V4: Keyboard navigation handler
   _handleKeyDown(e) {
     // Handle keyboard navigation
@@ -8631,6 +8801,9 @@ class MediaCard extends LitElement {
       this._pendingNavigationIndex = null;
       this._log('✅ Applied pending navigation index on image load');
     }
+    
+    // Shared queue: broadcast navigation to other cards with same shared_queue_id
+    this._writeSharedQueueState();
     
     // Trigger re-render to show updated metadata/counters
     this.requestUpdate();
@@ -13377,8 +13550,8 @@ class MediaCard extends LitElement {
     }
 
     .action-btn {
-      background: rgba(var(--rgb-card-background-color, 33, 33, 33), 0.8);
-      border: 1px solid rgba(var(--rgb-primary-text-color, 255, 255, 255), 0.2);
+      background: rgba(0, 0, 0, 0.55);
+      border: 1px solid rgba(255, 255, 255, 0.3);
       border-radius: 50%;
       width: 40px;
       height: 40px;
@@ -13387,70 +13560,86 @@ class MediaCard extends LitElement {
       justify-content: center;
       cursor: pointer;
       transition: all 0.2s ease;
-      color: var(--primary-text-color);
+      color: #ffffff;
       backdrop-filter: blur(10px);
     }
 
     .action-btn:hover {
-      background: rgba(var(--rgb-card-background-color, 33, 33, 33), 0.95);
+      background: rgba(0, 0, 0, 0.75);
       transform: scale(1.15);
-      border-color: rgba(var(--rgb-primary-text-color, 255, 255, 255), 0.4);
+      border-color: rgba(255, 255, 255, 0.5);
     }
 
     .action-btn ha-icon {
       --mdc-icon-size: 24px;
+      color: #ffffff;
     }
 
     /* V4: Highlight pause button when paused */
     .pause-btn.paused {
-      color: var(--primary-color, #03a9f4);
-      background: rgba(3, 169, 244, 0.15);
+      background: rgba(3, 169, 244, 0.3);
     }
 
     .pause-btn.paused:hover {
-      color: var(--primary-color, #03a9f4);
-      background: rgba(3, 169, 244, 0.25);
+      background: rgba(3, 169, 244, 0.45);
+    }
+
+    .pause-btn.paused ha-icon {
+      color: #03a9f4;
     }
 
     /* V5.6.12: Mute button - highlight when muted */
     .mute-btn.muted {
-      color: var(--warning-color, #ff9800);
-      background: rgba(255, 152, 0, 0.15);
+      background: rgba(255, 152, 0, 0.3);
     }
 
     .mute-btn.muted:hover {
-      color: var(--warning-color, #ff9800);
-      background: rgba(255, 152, 0, 0.25);
+      background: rgba(255, 152, 0, 0.45);
+    }
+
+    .mute-btn.muted ha-icon {
+      color: #ff9800;
     }
 
     /* Debug button active state - warning color when enabled */
     .debug-btn.active {
-      color: var(--warning-color, #ff9800);
-      background: rgba(255, 152, 0, 0.15);
+      background: rgba(255, 152, 0, 0.3);
     }
 
     .debug-btn.active:hover {
-      color: var(--warning-color, #ff9800);
-      background: rgba(255, 152, 0, 0.25);
+      background: rgba(255, 152, 0, 0.45);
+    }
+
+    .debug-btn.active ha-icon {
+      color: #ff9800;
     }
 
     .favorite-btn.favorited {
-      color: var(--error-color, #ff5252);
-    }
-
-    .favorite-btn.favorited:hover {
-      color: var(--error-color, #ff5252);
       background: rgba(255, 82, 82, 0.1);
     }
 
+    .favorite-btn.favorited:hover {
+      background: rgba(255, 82, 82, 0.25);
+    }
+
+    .favorite-btn.favorited ha-icon {
+      color: #ff5252;
+    }
+
     .edit-btn:hover {
-      color: var(--warning-color, #ff9800);
       transform: scale(1.15);
     }
 
+    .edit-btn:hover ha-icon {
+      color: #ff9800;
+    }
+
     .delete-btn:hover {
-      color: var(--error-color, #ff5252);
       transform: scale(1.15);
+    }
+
+    .delete-btn:hover ha-icon {
+      color: #ff5252;
     }
 
     /* V4: Delete/Edit Confirmation Dialog */
@@ -13907,33 +14096,39 @@ class MediaCard extends LitElement {
     }
 
     .info-btn.active {
-      color: var(--primary-color, #03a9f4);
-      background: rgba(3, 169, 244, 0.15);
+      background: rgba(3, 169, 244, 0.3);
     }
 
     .info-btn.active:hover {
-      color: var(--primary-color, #03a9f4);
-      background: rgba(3, 169, 244, 0.25);
+      background: rgba(3, 169, 244, 0.45);
+    }
+
+    .info-btn.active ha-icon {
+      color: #03a9f4;
     }
     
     .burst-btn.active {
-      color: var(--primary-color, #03a9f4);
-      background: rgba(3, 169, 244, 0.15);
+      background: rgba(3, 169, 244, 0.3);
     }
 
     .burst-btn.active:hover {
-      color: var(--primary-color, #03a9f4);
-      background: rgba(3, 169, 244, 0.25);
+      background: rgba(3, 169, 244, 0.45);
+    }
+
+    .burst-btn.active ha-icon {
+      color: #03a9f4;
     }
     
     .queue-btn.active {
-      color: var(--primary-color, #03a9f4);
-      background: rgba(3, 169, 244, 0.15);
+      background: rgba(3, 169, 244, 0.3);
     }
 
     .queue-btn.active:hover {
-      color: var(--primary-color, #03a9f4);
-      background: rgba(3, 169, 244, 0.25);
+      background: rgba(3, 169, 244, 0.45);
+    }
+
+    .queue-btn.active ha-icon {
+      color: #03a9f4;
     }
     
     .placeholder {
@@ -18709,6 +18904,25 @@ Tip: Check your Home Assistant media folder in Settings > System > Storage`;
               <div class="help-text">Check for new files every N seconds (0 = disabled). Single media: reloads image URL. Folder mode: checks for new files and refreshes queue if at newest position.</div>
             </div>
           </div>
+
+          <div class="config-row">
+            <label>Shared Queue ID</label>
+            <div>
+              <input
+                type="text"
+                .value=${this._config.shared_queue_id || ''}
+                @input=${(e) => {
+                  const val = e.target.value.trim();
+                  this._config = val
+                    ? { ...this._config, shared_queue_id: val }
+                    : (() => { const c = { ...this._config }; delete c.shared_queue_id; return c; })();
+                  this.dispatchEvent(new CustomEvent('config-changed', { detail: { config: this._config } }));
+                }}
+                placeholder="e.g. main-slideshow"
+              />
+              <div class="help-text">Optional. Cards with the same ID share their queue and position across views on the same device. Leave empty to disable.</div>
+            </div>
+          </div>
         </div>
 
         ${mediaSourceType === 'folder' ? html`
@@ -19515,7 +19729,7 @@ if (!window.customCards.some(card => card.type === 'media-card')) {
 }
 
 console.info(
-  '%c  MEDIA-CARD  %c  v5.9.0 Loaded  ',
+  '%c  MEDIA-CARD  %c  v5.10.0 Loaded  ',
   'color: lime; font-weight: bold; background: black',
   'color: white; font-weight: bold; background: green'
 );

--- a/ha-media-card.js
+++ b/ha-media-card.js
@@ -8544,6 +8544,7 @@ class MediaCard extends LitElement {
           pause_intent: pauseIntent,
           source_card_id: this._cardId,
           current_metadata: JSON.stringify(this._currentMetadata || this._pendingMetadata || null),
+          written_at: Date.now(),
         },
         target: { entity_id: entityId },
       });
@@ -8736,6 +8737,7 @@ class MediaCard extends LitElement {
       currentMetadata,
       isPaused: data.is_paused,
       pauseIntent: data.pause_intent,
+      updatedAt: data.written_at || 0,
     });
   }
 
@@ -8779,6 +8781,18 @@ class MediaCard extends LitElement {
   // Apply an incoming queue update from any transport
   _applySharedQueueUpdate(data) {
     if (!Array.isArray(data.queue) || !data.queue.length) return;
+
+    // Reject stale events that arrive out of order. Each write includes a
+    // written_at/updatedAt timestamp (ms epoch). If this event is older than the
+    // most recent one already applied, discard it — it is a delayed HA event from
+    // a previous navigation that arrived after a newer write already advanced us.
+    const eventTs = data.updatedAt || 0;
+    if (eventTs && eventTs < (this._lastAppliedSyncAt || 0)) {
+      this._log(`⏩ Discarding stale sync event (ts=${eventTs}, last=${this._lastAppliedSyncAt})`);
+      return;
+    }
+    if (eventTs) this._lastAppliedSyncAt = eventTs;
+
     const newIndex = Math.min(
       typeof data.currentIndex === 'number' ? data.currentIndex : 0,
       data.queue.length - 1

--- a/ha-media-card.js
+++ b/ha-media-card.js
@@ -4914,6 +4914,22 @@ class MediaCard extends LitElement {
     // Shared queue: register event listeners (cross-device HA events + same-device)
     this._subscribeToSyncEvents();
 
+    // Leader election: try to become the timer leader for this sync group.
+    // If the slot is empty this card claims it; otherwise it defers to the current leader.
+    this._tryClaimLeadership();
+
+    // Listen for the vacancy event fired when the leader disconnects, so a follower
+    // can step up and start its own timer.
+    this._leaderVacatedHandler = (e) => {
+      if (e.detail?.sharedQueueId !== this.config?.shared_queue_id) return;
+      const claimed = this._tryClaimLeadership();
+      if (claimed) {
+        this._log('👑 Stepping up as leader after vacancy — starting timer');
+        this._setupAutoRefresh();
+      }
+    };
+    window.addEventListener('ha-media-card-leader-vacated', this._leaderVacatedHandler);
+
     // Shared queue: if reconnecting (provider already exists), sync state from
     // media-index or localStorage to pick up where the other card left off
     if (this.provider && this.config?.shared_queue_id) {
@@ -4931,7 +4947,15 @@ class MediaCard extends LitElement {
     
     // Shared queue: remove all event listeners and cancel pending debounced write
     this._unsubscribeFromSyncEvents();
-    
+
+    // Leader election: remove the vacancy listener and release leadership.
+    // _relinquishLeadership fires ha-media-card-leader-vacated so a follower steps up.
+    if (this._leaderVacatedHandler) {
+      window.removeEventListener('ha-media-card-leader-vacated', this._leaderVacatedHandler);
+      this._leaderVacatedHandler = null;
+    }
+    this._relinquishLeadership();
+
     // V5.6: Cleanup viewport height observer
     this._cleanupDynamicViewportHeight();
     
@@ -5995,6 +6019,12 @@ class MediaCard extends LitElement {
       // The browser auto-pauses videos when they're removed from DOM
       this._navigatingAway = true;
 
+      // Leader election: if the user tapped/swiped on this card, it becomes the
+      // new timer driver for the sync group, displacing any existing leader.
+      if (this._isManualNavigation && this.config?.shared_queue_id) {
+        this._forceClaimLeadership();
+      }
+
     // V5.5: Panel Navigation Override (burst/related/on_this_day use _panelQueue)
     // Queue preview mode uses navigationQueue directly, so skip panel navigation
     if (this._panelOpen && this._panelQueue.length > 0 && this._panelMode !== 'queue') {
@@ -6245,6 +6275,12 @@ class MediaCard extends LitElement {
     try {
       // V5.6: Set flag FIRST to ignore video pause events during navigation
       this._navigatingAway = true;
+
+      // Leader election: if the user tapped/swiped on this card, it becomes the
+      // new timer driver for the sync group, displacing any existing leader.
+      if (this._isManualNavigation && this.config?.shared_queue_id) {
+        this._forceClaimLeadership();
+      }
 
       // V5.5: Panel Navigation Override (burst/related/on_this_day use _panelQueue)
       // Queue preview mode uses navigationQueue directly, so skip panel navigation
@@ -6608,6 +6644,13 @@ class MediaCard extends LitElement {
     
     if (this._backgroundPaused) {
       this._log('🔄 Auto-refresh setup skipped - background paused (not visible)');
+      return;
+    }
+
+    // Leader election: followers in a sync group must not run their own timer.
+    // The leader broadcasts navigation events; followers apply them via _applySharedQueueUpdate.
+    if (this.config?.shared_queue_id && !this._isSyncLeader()) {
+      this._log('👥 Sync follower — timer suppressed (leader handles advance)');
       return;
     }
 
@@ -8728,6 +8771,69 @@ class MediaCard extends LitElement {
       clearTimeout(this._syncWriteTimer);
       this._syncWriteTimer = null;
     }
+  }
+
+  // Same-window leader election for shared_queue_id groups.
+  // Only the leader card runs the auto-advance timer; followers suppress theirs.
+  // This prevents two card instances (e.g. on different views of the same dashboard)
+  // from both firing timers and competing over which index to broadcast.
+
+  /** Returns true if this card is (or should act as) the timer leader. */
+  _isSyncLeader() {
+    const id = this.config?.shared_queue_id;
+    if (!id) return true; // No sync group — always act as leader
+    if (!window._mediaCardLeaders) return false;
+    return window._mediaCardLeaders.get(id) === this._cardId;
+  }
+
+  /**
+   * Attempt to register this card as the leader for its sync group.
+   * Succeeds only if the slot is empty.  Returns true if leadership was
+   * claimed (or was already held), false if another card holds the slot.
+   */
+  _tryClaimLeadership() {
+    const id = this.config?.shared_queue_id;
+    if (!id) return true;
+    if (!window._mediaCardLeaders) window._mediaCardLeaders = new Map();
+    const current = window._mediaCardLeaders.get(id);
+    if (!current) {
+      window._mediaCardLeaders.set(id, this._cardId);
+      this._log(`👑 Claimed sync leadership for group '${id}'`);
+      return true;
+    }
+    if (current === this._cardId) return true; // Already the leader
+    this._log(`👥 Sync follower for group '${id}' (leader: ${current})`);
+    return false;
+  }
+
+  /**
+   * Force-claim leadership, displacing any current leader.
+   * Used when the user manually navigates on a follower card — the active
+   * device should become the driver to avoid the old leader overriding it.
+   */
+  _forceClaimLeadership() {
+    const id = this.config?.shared_queue_id;
+    if (!id) return;
+    if (!window._mediaCardLeaders) window._mediaCardLeaders = new Map();
+    const prev = window._mediaCardLeaders.get(id);
+    if (prev === this._cardId) return; // Already leader
+    window._mediaCardLeaders.set(id, this._cardId);
+    this._log(`👑 Force-claimed sync leadership for group '${id}' (displaced: ${prev})`);
+  }
+
+  /**
+   * Release leadership and notify followers so one can step up.
+   * Called from disconnectedCallback.
+   */
+  _relinquishLeadership() {
+    const id = this.config?.shared_queue_id;
+    if (!id || !window._mediaCardLeaders) return;
+    if (window._mediaCardLeaders.get(id) !== this._cardId) return;
+    window._mediaCardLeaders.delete(id);
+    this._log(`👋 Relinquished sync leadership for group '${id}'`);
+    window.dispatchEvent(new CustomEvent('ha-media-card-leader-vacated', {
+      detail: { sharedQueueId: id }
+    }));
   }
 
   // HA websocket event from media_index (cross-device)

--- a/ha-media-card.js
+++ b/ha-media-card.js
@@ -6185,6 +6185,12 @@ class MediaCard extends LitElement {
               // the provider (same-window CustomEvent fires mid-await), follow that card instead.
               if ((this._syncNavGeneration || 0) > _syncGenBefore) {
                 this._log('🔗 Another synced card broadcast first — following sync navigation, discarding locally-fetched item');
+                // IMPORTANT: also remove the item we just pushed from navigationQueue.
+                // _applySharedQueueUpdate replaced navigationQueue with the driver's queue,
+                // then our push added this item on top.  If we don't remove it, the next
+                // auto-advance will find the queue non-exhausted and navigate to this item
+                // directly — bypassing the follower defer check entirely.
+                this.navigationQueue.pop();
                 return;
               }
               // We are the "first" card — broadcast our new item immediately so other

--- a/ha-media-card.js
+++ b/ha-media-card.js
@@ -8898,7 +8898,19 @@ class MediaCard extends LitElement {
     if (!id) return;
     if (!window._mediaCardLeaders) window._mediaCardLeaders = new Map();
     const prev = window._mediaCardLeaders.get(id);
-    if (prev === this._cardId) return; // Already leader
+
+    // Always clear the echo-suppression window regardless of whether leadership
+    // changes. A sync event from the follower may have set _suppressSyncWriteUntil
+    // on this card just before the user manually navigated – if we don't clear it
+    // here, the post-load _writeSharedQueueState() call is silently dropped even
+    // when this card is (and remains) the leader.
+    this._suppressSyncWriteUntil = 0;
+    if (this._syncWriteTimer) {
+      clearTimeout(this._syncWriteTimer);
+      this._syncWriteTimer = null;
+    }
+
+    if (prev === this._cardId) return; // Already leader — suppression cleared above ✓
     window._mediaCardLeaders.set(id, this._cardId);
     // Also clear the cross-device follower deferral — the user is actively driving
     // from this device so it should immediately write to the shared DB state.
@@ -8909,15 +8921,6 @@ class MediaCard extends LitElement {
     if (this._crossDeviceGraceRetryTimer) {
       clearTimeout(this._crossDeviceGraceRetryTimer);
       this._crossDeviceGraceRetryTimer = null;
-    }
-    // Clear the echo-suppression window set by _applySharedQueueUpdate.
-    // Without this, the first _writeSharedQueueState() call after taking control
-    // is silently dropped (and the pending debounce timer is also cancelled), so
-    // the other device never receives the HA sync event for the manual navigation.
-    this._suppressSyncWriteUntil = 0;
-    if (this._syncWriteTimer) {
-      clearTimeout(this._syncWriteTimer);
-      this._syncWriteTimer = null;
     }
     this._log(`👑 Force-claimed sync leadership for group '${id}' (displaced: ${prev})`);
   }

--- a/ha-media-card.js
+++ b/ha-media-card.js
@@ -8910,6 +8910,15 @@ class MediaCard extends LitElement {
       clearTimeout(this._crossDeviceGraceRetryTimer);
       this._crossDeviceGraceRetryTimer = null;
     }
+    // Clear the echo-suppression window set by _applySharedQueueUpdate.
+    // Without this, the first _writeSharedQueueState() call after taking control
+    // is silently dropped (and the pending debounce timer is also cancelled), so
+    // the other device never receives the HA sync event for the manual navigation.
+    this._suppressSyncWriteUntil = 0;
+    if (this._syncWriteTimer) {
+      clearTimeout(this._syncWriteTimer);
+      this._syncWriteTimer = null;
+    }
     this._log(`👑 Force-claimed sync leadership for group '${id}' (displaced: ${prev})`);
   }
 

--- a/ha-media-card.js
+++ b/ha-media-card.js
@@ -8543,20 +8543,19 @@ class MediaCard extends LitElement {
     // Echo-prevention: skip the write that would bounce an incoming navigation sync
     // back to the sender. BUT always allow explicit pause/resume writes through so
     // that a pause arriving simultaneously with a navigation doesn't get swallowed.
-    if (this._suppressSyncWrite && !pauseIntent) {
-      this._suppressSyncWrite = false;
-      // Also cancel any pending debounced DB write — it was queued before the sync
-      // event arrived and would still fire (bypassing _suppressSyncWrite) if not
-      // explicitly cancelled here.  Without this, a stale echo of the sender's own
-      // trimmed queue reaches the sender with a clamped index, corrupting the driver's
-      // navigation queue when the driver has since advanced to a different item.
+    // Uses a timestamp window instead of a one-shot boolean so that double-load events
+    // (e.g. rapid-navigation clearing both layers fires two onload events for the same
+    // URL) don't consume the flag on the first load and then write on the second.
+    if (!pauseIntent && this._suppressSyncWriteUntil && Date.now() < this._suppressSyncWriteUntil) {
+      // Don't clear _suppressSyncWriteUntil — let it expire naturally so subsequent
+      // loads within the same sync event window are also suppressed.
       if (this._syncWriteTimer) {
         clearTimeout(this._syncWriteTimer);
         this._syncWriteTimer = null;
       }
       return;
     }
-    this._suppressSyncWrite = false;
+    this._suppressSyncWriteUntil = 0;
 
     // Always write localStorage for instant same-device sync
     try {
@@ -8579,7 +8578,10 @@ class MediaCard extends LitElement {
     // Cross-device: debounced service call.
     // Accumulate pauseIntent across debounce resets so that a pause write that arrives
     // just before a navigation write doesn't silently lose the intent.
-    if (this._hasCrossDeviceSync()) {
+    // Cross-device write: only if we are acting as the driver (not a follower that
+    // recently received a sync event from another device).  Pause/resume intent always
+    // passes through so the user can group-pause from any device.
+    if (this._hasCrossDeviceSync() && (pauseIntent || Date.now() >= (this._crossDeviceFollowerUntil || 0))) {
       this._pendingSyncPauseIntent = (this._pendingSyncPauseIntent || false) || pauseIntent;
       if (this._syncWriteTimer) clearTimeout(this._syncWriteTimer);
       this._syncWriteTimer = setTimeout(() => {
@@ -8844,6 +8846,9 @@ class MediaCard extends LitElement {
     const prev = window._mediaCardLeaders.get(id);
     if (prev === this._cardId) return; // Already leader
     window._mediaCardLeaders.set(id, this._cardId);
+    // Also clear the cross-device follower deferral — the user is actively driving
+    // from this device so it should immediately write to the shared DB state.
+    this._crossDeviceFollowerUntil = 0;
     this._log(`👑 Force-claimed sync leadership for group '${id}' (displaced: ${prev})`);
   }
 
@@ -8869,6 +8874,12 @@ class MediaCard extends LitElement {
     if (!id || data?.sync_group !== id) return;
     // Ignore events we ourselves wrote (media_index echoes back to all subscribers)
     if (data?.source_card_id === this._cardId) return;
+    // Mark this card as a cross-device follower for 30 s.  While in follower mode,
+    // auto-advance writes are suppressed so this card doesn't overwrite the driver's
+    // DB state with its own independently-fetched queue items.  The window is generous
+    // enough to cover normal slideshow intervals; if the driver goes away, this card
+    // will naturally take over writing once the window expires.
+    this._crossDeviceFollowerUntil = Date.now() + 30000;
     let currentMetadata = null;
     if (data.current_metadata) {
       try { currentMetadata = JSON.parse(data.current_metadata); } catch (_e) {}
@@ -9011,9 +9022,10 @@ class MediaCard extends LitElement {
     // works even when this card has no media-index configured.
     this._pendingMetadata = data.currentMetadata || null;
     // Suppress the outgoing write that would otherwise echo this event back.
-    // Also cancel any in-flight debounced write immediately — defence-in-depth so
-    // the timer can't fire between now and when _writeSharedQueueState is next called.
-    this._suppressSyncWrite = true;
+    // Use a 1-second window (timestamp) rather than a one-shot boolean so that the
+    // double-load race (rapid-navigation fires two onload events for the same URL)
+    // doesn't consume the flag prematurely on the first load.
+    this._suppressSyncWriteUntil = Date.now() + 1000;
     if (this._syncWriteTimer) {
       clearTimeout(this._syncWriteTimer);
       this._syncWriteTimer = null;

--- a/ha-media-card.js
+++ b/ha-media-card.js
@@ -9730,7 +9730,9 @@ class MediaCard extends LitElement {
     
     // Check individual button enable flags (default: true)
     const config = this.config.action_buttons || {};
-    const enablePause = config.enable_pause !== false;
+    // In single-media mode there is no auto-advance slideshow, so pause is irrelevant.
+    const isSingleMedia = this.config.media_source_type === 'single_media';
+    const enablePause = !isSingleMedia && config.enable_pause !== false;
     const enableFavorite = config.enable_favorite !== false;
     const enableDelete = config.enable_delete !== false;
     const enableEdit = config.enable_edit !== false;
@@ -9754,9 +9756,14 @@ class MediaCard extends LitElement {
     // Show button if enabled and queue has items (or still loading)
     const showQueueButton = enableQueuePreview && this.navigationQueue && this.navigationQueue.length >= 1;
     
-    // V5.6.12: Mute button - show unless slideshow is configured for images only
+    // Mute button: hide when media is image-only.
+    // For single-media mode, use the actual file extension of the current item so the
+    // button is hidden when showing an image even if media_type was not explicitly set.
+    // For slideshow modes, fall back to the config media_type filter.
     const mediaType = this.config.media_type || 'all';
-    const showMuteButton = mediaType !== 'image';  // Show for 'all' or 'video'
+    const showMuteButton = isSingleMedia
+      ? MediaUtils.detectFileType(this._currentMediaPath || '') === 'video'
+      : mediaType !== 'image';
     
     // Don't render anything if all buttons are disabled
     const anyButtonEnabled = enablePause || showMuteButton || enableDebugButton || enableRefresh || enableFullscreen || 

--- a/ha-media-card.js
+++ b/ha-media-card.js
@@ -6025,7 +6025,7 @@ class MediaCard extends LitElement {
       // user wants to control THIS card and it should fetch from its own provider,
       // not wait for a cross-device broadcast.
       if (this._isManualNavigation && this.config?.shared_queue_id) {
-        this._forceClaimLeadership();
+        this._claimDriverRole();
       }
 
     // V5.5: Panel Navigation Override (burst/related/on_this_day use _panelQueue)
@@ -6324,7 +6324,7 @@ class MediaCard extends LitElement {
       // This applies even when locally paused — an explicit button press means the
       // user wants to control THIS card.
       if (this._isManualNavigation && this.config?.shared_queue_id) {
-        this._forceClaimLeadership();
+        this._claimDriverRole();
       }
 
       // V5.5: Panel Navigation Override (burst/related/on_this_day use _panelQueue)
@@ -8893,37 +8893,54 @@ class MediaCard extends LitElement {
    * Used when the user manually navigates on a follower card — the active
    * device should become the driver to avoid the old leader overriding it.
    */
-  _forceClaimLeadership() {
+  /**
+   * Called on every manual navigation.  Handles TWO distinct but related concepts:
+   *
+   * Tier 1 — Same-window timer leadership (window._mediaCardLeaders):
+   *   Only one card per browser tab runs the auto-advance timer.  Manually
+   *   navigating on any card promotes it to timer leader, displacing any other
+   *   card that held the slot.  This prevents two timers competing on the same tab.
+   *
+   * Tier 2 — Cross-device HA write driver (_crossDeviceFollowerUntil):
+   *   Whichever browser/device the user is actively navigating on should write to
+   *   the HA media_index sync state.  Receiving a sync event from another device
+   *   sets _crossDeviceFollowerUntil = now+30s on this card, which blocks the HA
+   *   debounce write.  Manual navigation must clear that deferral unconditionally —
+   *   even if same-window leadership didn't change — so the HA write goes through
+   *   and the other browser receives the navigation update.
+   *
+   * Both tiers' state is reset BEFORE the early-return guard.  That guard only
+   * skips the window._mediaCardLeaders map update and log line; it must never
+   * skip the state resets.
+   */
+  _claimDriverRole() {
     const id = this.config?.shared_queue_id;
     if (!id) return;
     if (!window._mediaCardLeaders) window._mediaCardLeaders = new Map();
     const prev = window._mediaCardLeaders.get(id);
 
-    // Always clear ALL follower-mode state regardless of whether local window
-    // leadership changes.  A sync event from another device sets both
-    // _suppressSyncWriteUntil (echo guard) and _crossDeviceFollowerUntil (HA write
-    // gate) on this card.  If we only clear these when displacing a different local
-    // leader, manual navigation on the already-local-leader card still gets blocked
-    // from writing to HA — the other browser never receives the navigation.
-    this._suppressSyncWriteUntil = 0;
-    if (this._syncWriteTimer) {
-      clearTimeout(this._syncWriteTimer);
-      this._syncWriteTimer = null;
-    }
-    // Clear the cross-device follower deferral — the user is actively driving
-    // from this device so it should immediately write to the shared HA state.
+    // ── Tier 2: cross-device driver mode ──────────────────────────────────────
+    // Clear ALL cross-device follower/deferral state so the HA write goes through
+    // immediately, regardless of whether same-window leadership is changing.
     this._crossDeviceFollowerUntil = 0;
-    // And clear the reconnect grace — user took control so local provider fetches
-    // are welcome immediately.
     this._crossDeviceProviderFetchUntil = 0;
     if (this._crossDeviceGraceRetryTimer) {
       clearTimeout(this._crossDeviceGraceRetryTimer);
       this._crossDeviceGraceRetryTimer = null;
     }
+    // Clear the echo-suppression window.  A sync event from the other device may
+    // have set _suppressSyncWriteUntil just before the user navigated — without
+    // this reset the post-load _writeSharedQueueState() call would be dropped.
+    this._suppressSyncWriteUntil = 0;
+    if (this._syncWriteTimer) {
+      clearTimeout(this._syncWriteTimer);
+      this._syncWriteTimer = null;
+    }
 
-    if (prev === this._cardId) return; // Already local leader — state cleared above ✓
+    // ── Tier 1: same-window timer leadership ──────────────────────────────────
+    if (prev === this._cardId) return; // Already this tab's timer leader — Tier 2 reset above is sufficient ✓
     window._mediaCardLeaders.set(id, this._cardId);
-    this._log(`👑 Force-claimed sync leadership for group '${id}' (displaced: ${prev})`);
+    this._log(`👑 Claimed driver role for group '${id}' (displaced same-window leader: ${prev})`);
   }
 
   /**
@@ -9038,7 +9055,7 @@ class MediaCard extends LitElement {
 
     // If the user pressed a button on THIS device while the sync arrived, let the
     // manual navigation win.  The manual _loadNext/_loadPrevious already called
-    // _forceClaimLeadership() which cleared _crossDeviceFollowerUntil; and
+    // _claimDriverRole() which cleared _crossDeviceFollowerUntil; and
     // _onHaSyncEvent already returned early so _crossDeviceFollowerUntil was not
     // re-set.  Nothing further to do here — the manual fetch will complete and
     // broadcast its own sync event to the driver.

--- a/ha-media-card.js
+++ b/ha-media-card.js
@@ -6075,6 +6075,18 @@ class MediaCard extends LitElement {
           this._pendingNavigationIndex = 0;
         } else {
           this._log('Navigation queue exhausted, loading from provider');
+          // Cross-device reconnect grace: when restoring at the last queue slot the
+          // driving device may be about to broadcast its next item.  Defer our own
+          // provider fetch so we follow the driver rather than racing it with a
+          // different item that would briefly flash on-screen before the sync corrects.
+          if (this._crossDeviceProviderFetchUntil && Date.now() < this._crossDeviceProviderFetchUntil) {
+            const remaining = this._crossDeviceProviderFetchUntil - Date.now();
+            this._log(`⏳ Cross-device grace: deferring provider fetch ${remaining}ms`);
+            // Retry when the window expires; a sync event clears the flag early.
+            setTimeout(() => { if (!this._isLocallyPaused()) this._loadNext(); }, remaining + 50);
+            return;
+          }
+          this._crossDeviceProviderFetchUntil = 0;
           // Capture generation before any awaits so we can detect if a sync event
           // arrived from another card while we were waiting for the provider.
           const _syncGenBefore = this._syncNavGeneration || 0;
@@ -8738,6 +8750,15 @@ class MediaCard extends LitElement {
       this.navigationQueue.length - 1
     );
     this._log(`🔗 Shared queue restored: ${this.navigationQueue.length} items, index ${this.navigationIndex}`);
+    // Cross-device reconnect grace period: when we restore at the last (or only) slot
+    // the driver may be about to extend the queue and broadcast the next item.  Enter a
+    // short deferral window so the HA sync event arrives before we independently fetch a
+    // (potentially different) item from our own provider.  The window is cleared as soon
+    // as a sync event is received (in _applySharedQueueUpdate).
+    if (this._hasCrossDeviceSync() && this.navigationIndex >= this.navigationQueue.length - 1) {
+      this._crossDeviceProviderFetchUntil = Date.now() + 3000;
+      this._log('⏳ Cross-device grace period started (3s) — restored at end of shared queue');
+    }
     return true;
   }
 
@@ -8849,6 +8870,9 @@ class MediaCard extends LitElement {
     // Also clear the cross-device follower deferral — the user is actively driving
     // from this device so it should immediately write to the shared DB state.
     this._crossDeviceFollowerUntil = 0;
+    // And clear the reconnect grace — user took control so local provider fetches
+    // are welcome immediately.
+    this._crossDeviceProviderFetchUntil = 0;
     this._log(`👑 Force-claimed sync leadership for group '${id}' (displaced: ${prev})`);
   }
 
@@ -8945,6 +8969,10 @@ class MediaCard extends LitElement {
       return;
     }
     if (eventTs) this._lastAppliedSyncAt = eventTs;
+
+    // Clear reconnect grace period — the driver has broadcast its next item so
+    // we no longer need to defer provider fetches.
+    this._crossDeviceProviderFetchUntil = 0;
 
     const newIndex = Math.min(
       typeof data.currentIndex === 'number' ? data.currentIndex : 0,

--- a/ha-media-card.js
+++ b/ha-media-card.js
@@ -8899,21 +8899,19 @@ class MediaCard extends LitElement {
     if (!window._mediaCardLeaders) window._mediaCardLeaders = new Map();
     const prev = window._mediaCardLeaders.get(id);
 
-    // Always clear the echo-suppression window regardless of whether leadership
-    // changes. A sync event from the follower may have set _suppressSyncWriteUntil
-    // on this card just before the user manually navigated – if we don't clear it
-    // here, the post-load _writeSharedQueueState() call is silently dropped even
-    // when this card is (and remains) the leader.
+    // Always clear ALL follower-mode state regardless of whether local window
+    // leadership changes.  A sync event from another device sets both
+    // _suppressSyncWriteUntil (echo guard) and _crossDeviceFollowerUntil (HA write
+    // gate) on this card.  If we only clear these when displacing a different local
+    // leader, manual navigation on the already-local-leader card still gets blocked
+    // from writing to HA — the other browser never receives the navigation.
     this._suppressSyncWriteUntil = 0;
     if (this._syncWriteTimer) {
       clearTimeout(this._syncWriteTimer);
       this._syncWriteTimer = null;
     }
-
-    if (prev === this._cardId) return; // Already leader — suppression cleared above ✓
-    window._mediaCardLeaders.set(id, this._cardId);
-    // Also clear the cross-device follower deferral — the user is actively driving
-    // from this device so it should immediately write to the shared DB state.
+    // Clear the cross-device follower deferral — the user is actively driving
+    // from this device so it should immediately write to the shared HA state.
     this._crossDeviceFollowerUntil = 0;
     // And clear the reconnect grace — user took control so local provider fetches
     // are welcome immediately.
@@ -8922,6 +8920,9 @@ class MediaCard extends LitElement {
       clearTimeout(this._crossDeviceGraceRetryTimer);
       this._crossDeviceGraceRetryTimer = null;
     }
+
+    if (prev === this._cardId) return; // Already local leader — state cleared above ✓
+    window._mediaCardLeaders.set(id, this._cardId);
     this._log(`👑 Force-claimed sync leadership for group '${id}' (displaced: ${prev})`);
   }
 

--- a/ha-media-card.js
+++ b/ha-media-card.js
@@ -6075,13 +6075,23 @@ class MediaCard extends LitElement {
           this._pendingNavigationIndex = 0;
         } else {
           this._log('Navigation queue exhausted, loading from provider');
-          // Cross-device reconnect grace: when restoring at the last queue slot the
-          // driving device may be about to broadcast its next item.  Defer our own
-          // provider fetch so we follow the driver rather than racing it with a
-          // different item.  The grace window equals the slide interval + 3s buffer.
-          if (this._crossDeviceProviderFetchUntil && Date.now() < this._crossDeviceProviderFetchUntil) {
-            const remaining = this._crossDeviceProviderFetchUntil - Date.now();
-            this._log(`⏳ Cross-device grace: deferring provider fetch ${remaining}ms`);
+          // Cross-device follower mode: if this card received an HA sync event recently
+          // it means another device is the active driver.  Defer provider fetches and wait
+          // for the driver to broadcast the next item.  This cleanly prevents both devices
+          // independently fetching different items and causing flashes during normal running
+          // — not just at reconnect.  After _crossDeviceFollowerUntil expires (30s with no
+          // sync events) the card is free to fetch on its own (driver has gone away).
+          const _nowMs = Date.now();
+          const _followerDefer = this._crossDeviceFollowerUntil && _nowMs < this._crossDeviceFollowerUntil;
+          const _reconnectDefer = this._crossDeviceProviderFetchUntil && _nowMs < this._crossDeviceProviderFetchUntil;
+          if (_followerDefer || _reconnectDefer) {
+            // Use the longer of the two windows as the remaining deferral time.
+            const remaining = Math.max(
+              _followerDefer ? this._crossDeviceFollowerUntil - _nowMs : 0,
+              _reconnectDefer ? this._crossDeviceProviderFetchUntil - _nowMs : 0
+            );
+            const reason = _followerDefer ? 'follower mode (driver active)' : 'reconnect grace';
+            this._log(`⏳ Cross-device defer (${reason}): waiting ${remaining}ms for driver broadcast`);
             // Store the retry timer so it can be cancelled if a sync event arrives first.
             if (this._crossDeviceGraceRetryTimer) clearTimeout(this._crossDeviceGraceRetryTimer);
             this._crossDeviceGraceRetryTimer = setTimeout(() => {

--- a/ha-media-card.js
+++ b/ha-media-card.js
@@ -6021,8 +6021,10 @@ class MediaCard extends LitElement {
 
       // Leader election: if the user tapped/swiped on this card, it becomes the
       // new timer driver for the sync group, displacing any existing leader.
-      // Exception: locally paused (short press) — navigate silently without affecting group.
-      if (this._isManualNavigation && this.config?.shared_queue_id && !this._isLocallyPaused()) {
+      // This applies even when locally paused — an explicit button press means the
+      // user wants to control THIS card and it should fetch from its own provider,
+      // not wait for a cross-device broadcast.
+      if (this._isManualNavigation && this.config?.shared_queue_id) {
         this._forceClaimLeadership();
       }
 
@@ -6311,8 +6313,9 @@ class MediaCard extends LitElement {
 
       // Leader election: if the user tapped/swiped on this card, it becomes the
       // new timer driver for the sync group, displacing any existing leader.
-      // Exception: locally paused (short press) — navigate silently without affecting group.
-      if (this._isManualNavigation && this.config?.shared_queue_id && !this._isLocallyPaused()) {
+      // This applies even when locally paused — an explicit button press means the
+      // user wants to control THIS card.
+      if (this._isManualNavigation && this.config?.shared_queue_id) {
         this._forceClaimLeadership();
       }
 

--- a/ha-media-card.js
+++ b/ha-media-card.js
@@ -6077,34 +6077,36 @@ class MediaCard extends LitElement {
           this._pendingNavigationIndex = 0;
         } else {
           this._log('Navigation queue exhausted, loading from provider');
-          // Cross-device follower mode: if this card received an HA sync event recently
-          // it means another device is the active driver.  Defer provider fetches and wait
-          // for the driver to broadcast the next item.  This cleanly prevents both devices
-          // independently fetching different items and causing flashes during normal running
-          // — not just at reconnect.  After _crossDeviceFollowerUntil expires (30s with no
-          // sync events) the card is free to fetch on its own (driver has gone away).
           const _nowMs = Date.now();
-          const _followerDefer = this._crossDeviceFollowerUntil && _nowMs < this._crossDeviceFollowerUntil;
-          const _reconnectDefer = this._crossDeviceProviderFetchUntil && _nowMs < this._crossDeviceProviderFetchUntil;
-          if (_followerDefer || _reconnectDefer) {
-            // Use the longer of the two windows as the remaining deferral time.
-            const remaining = Math.max(
-              _followerDefer ? this._crossDeviceFollowerUntil - _nowMs : 0,
-              _reconnectDefer ? this._crossDeviceProviderFetchUntil - _nowMs : 0
-            );
-            const reason = _followerDefer ? 'follower mode (driver active)' : 'reconnect grace';
-            this._log(`⏳ Cross-device defer (${reason}): waiting ${remaining}ms for driver broadcast`);
-            // Store the retry timer so it can be cancelled if a sync event arrives first.
+          const _followerDefer = !this._isManualNavigation &&
+              this._crossDeviceFollowerUntil && _nowMs < this._crossDeviceFollowerUntil;
+          const _reconnectDefer = !this._isManualNavigation &&
+              this._crossDeviceProviderFetchUntil && _nowMs < this._crossDeviceProviderFetchUntil;
+
+          if (_followerDefer) {
+            // Driver is active — it will broadcast when ready.  Return silently
+            // without queuing a retry; the retry was the source of endless noise.
+            // _applySharedQueueUpdate will navigate us when the broadcast arrives.
+            const waitSecs = Math.round((this._crossDeviceFollowerUntil - _nowMs) / 1000);
+            this._log(`⏳ Follower mode: waiting for driver broadcast (${waitSecs}s remaining)`);
+            return;
+          }
+
+          if (_reconnectDefer) {
+            // Reconnect grace: driver may still be active but HA event hasn't arrived yet.
+            // Set a one-shot retry; _applySharedQueueUpdate cancels it if broadcast arrives.
+            const remaining = this._crossDeviceProviderFetchUntil - _nowMs;
+            this._log(`⏳ Cross-device reconnect grace: deferring provider fetch ${remaining}ms`);
             if (this._crossDeviceGraceRetryTimer) clearTimeout(this._crossDeviceGraceRetryTimer);
             this._crossDeviceGraceRetryTimer = setTimeout(() => {
               this._crossDeviceGraceRetryTimer = null;
-              // Only retry if still at the end of the queue and no sync has advanced us.
               if (!this._isLocallyPaused() && this.navigationIndex >= this.navigationQueue.length - 1) {
                 this._loadNext();
               }
             }, remaining + 50);
             return;
           }
+
           this._crossDeviceProviderFetchUntil = 0;
           // Capture generation before any awaits so we can detect if a sync event
           // arrived from another card while we were waiting for the provider.
@@ -8927,6 +8929,13 @@ class MediaCard extends LitElement {
     if (!id || data?.sync_group !== id) return;
     // Ignore events we ourselves wrote (media_index echoes back to all subscribers)
     if (data?.source_card_id === this._cardId) return;
+    // If the user is actively pressing a button on this card, let the manual
+    // navigation complete first.  We do NOT extend the follower window because
+    // this card is in the middle of taking over as driver.
+    if (this._isManualNavigation) {
+      this._log('🔗 Manual nav in progress — not entering follower mode for this sync event');
+      return;
+    }
     // Mark this card as a cross-device follower for 30 s.  While in follower mode,
     // auto-advance writes are suppressed so this card doesn't overwrite the driver's
     // DB state with its own independently-fetched queue items.  The window is generous
@@ -9006,6 +9015,17 @@ class MediaCard extends LitElement {
     if (this._crossDeviceGraceRetryTimer) {
       clearTimeout(this._crossDeviceGraceRetryTimer);
       this._crossDeviceGraceRetryTimer = null;
+    }
+
+    // If the user pressed a button on THIS device while the sync arrived, let the
+    // manual navigation win.  The manual _loadNext/_loadPrevious already called
+    // _forceClaimLeadership() which cleared _crossDeviceFollowerUntil; and
+    // _onHaSyncEvent already returned early so _crossDeviceFollowerUntil was not
+    // re-set.  Nothing further to do here — the manual fetch will complete and
+    // broadcast its own sync event to the driver.
+    if (this._isManualNavigation) {
+      this._log('\ud83d\uddb1\ufe0f Manual navigation in progress — ignoring incoming sync navigation');
+      return;
     }
 
     const newIndex = Math.min(

--- a/ha-media-card.js
+++ b/ha-media-card.js
@@ -6021,7 +6021,8 @@ class MediaCard extends LitElement {
 
       // Leader election: if the user tapped/swiped on this card, it becomes the
       // new timer driver for the sync group, displacing any existing leader.
-      if (this._isManualNavigation && this.config?.shared_queue_id) {
+      // Exception: locally paused (short press) — navigate silently without affecting group.
+      if (this._isManualNavigation && this.config?.shared_queue_id && !this._isLocallyPaused()) {
         this._forceClaimLeadership();
       }
 
@@ -6155,7 +6156,10 @@ class MediaCard extends LitElement {
               }
               // We are the "first" card — broadcast our new item immediately so other
               // same-window cards adopt it synchronously before they exit their own awaits.
-              this._earlyBroadcastSyncState(nextIndex);
+              // Suppress if locally paused (short press) — don't affect the group.
+              if (!this._isLocallyPaused()) {
+                this._earlyBroadcastSyncState(nextIndex);
+              }
             }
           } else {
             // No more items available from provider, wrap to beginning with fresh query
@@ -6278,7 +6282,8 @@ class MediaCard extends LitElement {
 
       // Leader election: if the user tapped/swiped on this card, it becomes the
       // new timer driver for the sync group, displacing any existing leader.
-      if (this._isManualNavigation && this.config?.shared_queue_id) {
+      // Exception: locally paused (short press) — navigate silently without affecting group.
+      if (this._isManualNavigation && this.config?.shared_queue_id && !this._isLocallyPaused()) {
         this._forceClaimLeadership();
       }
 
@@ -8083,8 +8088,10 @@ class MediaCard extends LitElement {
       this._pendingMediaPath = null;
     }
     
-    // Shared queue: broadcast navigation to other cards with same shared_queue_id
-    this._writeSharedQueueState();
+    // Shared queue: broadcast navigation — suppress if locally paused (short press)
+    if (!this._isLocallyPaused()) {
+      this._writeSharedQueueState();
+    }
     
     this.requestUpdate();
   }
@@ -8775,6 +8782,16 @@ class MediaCard extends LitElement {
 
   // Same-window leader election for shared_queue_id groups.
   // Only the leader card runs the auto-advance timer; followers suppress theirs.
+
+  /**
+   * Returns true when this card is paused locally (short press) as opposed to
+   * a group pause (long press).  Locally paused cards navigate silently and
+   * ignore incoming sync navigation events.
+   */
+  _isLocallyPaused() {
+    return this._isPaused && !this._groupPaused;
+  }
+
   // This prevents two card instances (e.g. on different views of the same dashboard)
   // from both firing timers and competing over which index to broadcast.
 
@@ -8926,14 +8943,20 @@ class MediaCard extends LitElement {
     // continuously unpausing Device A.
     if (data.pauseIntent === true && typeof data.isPaused === 'boolean' && data.isPaused !== this._isPaused) {
       this._setPauseState(data.isPaused);
-      if (data.isPaused) { this._pauseTimer(); } else { this._resumeTimer(); }
+      if (data.isPaused) {
+        // Incoming group-pause: mark as group-paused so we know to broadcast on resume
+        this._groupPaused = true;
+        this._pauseTimer();
+      } else {
+        // Incoming group-resume: clear group-paused flag
+        this._groupPaused = false;
+        this._resumeTimer();
+      }
     }
 
-    // If this card is still paused after processing the intent, do not follow navigation
-    // from peers. The user intentionally paused this card; auto-advance from other running
-    // cards should not override that. A resume (pauseIntent=true, isPaused=false) will have
-    // already cleared _isPaused above, so the card resumes and still navigates.
-    if (this._isPaused) return;
+    // Locally paused (short press, not a group pause) — ignore sync navigation.
+    // Group-paused cards still follow navigation from the active card.
+    if (this._isPaused && !this._groupPaused) return;
 
     // Skip navigation if we are already showing this path OR already navigating to it.
     // The _pendingMediaPath check prevents duplicate navigation when the same update
@@ -9214,8 +9237,10 @@ class MediaCard extends LitElement {
       this._log('✅ Applied pending navigation index on image load');
     }
     
-    // Shared queue: broadcast navigation to other cards with same shared_queue_id
-    this._writeSharedQueueState();
+    // Shared queue: broadcast navigation — suppress if locally paused (short press)
+    if (!this._isLocallyPaused()) {
+      this._writeSharedQueueState();
+    }
     
     // Trigger re-render to show updated metadata/counters
     this.requestUpdate();
@@ -9746,9 +9771,12 @@ class MediaCard extends LitElement {
       <div class="action-buttons action-buttons-${position} ${this._showButtonsExplicitly ? 'show-buttons' : ''}">
         ${enablePause ? html`
           <button
-            class="action-btn pause-btn ${isPaused ? 'paused' : ''}"
+            class="action-btn pause-btn ${isPaused ? 'paused' : ''} ${isPaused && this._groupPaused ? 'group-paused' : ''}"
             @click=${this._handlePauseClick}
-            title="${isPaused ? 'Resume' : 'Pause'}">
+            @pointerdown=${this._handlePausePointerDown}
+            @pointerup=${this._handlePausePointerUp}
+            @pointercancel=${this._handlePausePointerUp}
+            title="${isPaused ? (this._groupPaused ? 'Resume Group' : 'Resume') : 'Pause'}">
             <ha-icon icon="${isPaused ? 'mdi:play' : 'mdi:pause'}"></ha-icon>
           </button>
         ` : ''}
@@ -10711,26 +10739,81 @@ class MediaCard extends LitElement {
   }
 
   // V4: Handle pause button click
+  // Short press = local pause/resume only (no broadcast to sync group).
+  // Long press (via _handlePausePointerDown) = group pause/resume (broadcasts).
   _handlePauseClick(e) {
     e.stopPropagation();
-    
+
     // Restart timer on touch (gives user full time to choose next action)
     if (this._showButtonsExplicitly) {
       this._startActionButtonsHideTimer();
     }
-    
-    this._setPauseState(!this._isPaused);
-    
-    // Stop timer when pausing, restart when resuming
-    if (this._isPaused) {
+
+    // Long press already handled group pause — absorb the click that follows
+    if (this._pauseLongPressed) {
+      this._pauseLongPressed = false;
+      return;
+    }
+
+    const wasPaused = this._isPaused;
+    this._setPauseState(!wasPaused);
+
+    if (!wasPaused) {
+      // Short press PAUSE — local only, no broadcast
+      this._groupPaused = false;
       this._pauseTimer();
-      this._log('🎮 PAUSED slideshow - timer stopped');
+      this._log('🎮 PAUSED locally - timer stopped (short press, no broadcast)');
+    } else {
+      // RESUME
+      if (this._groupPaused) {
+        // Was group-paused: broadcast resume so all cards resume
+        this._groupPaused = false;
+        this._resumeTimer();
+        this._log('▶️ RESUMED slideshow — broadcasting group resume');
+        this._writeSharedQueueState(true);
+      } else {
+        // Was locally paused: resume locally, no broadcast
+        // Timer restart will naturally resync with the leader on next advance
+        this._resumeTimer();
+        this._log('▶️ RESUMED locally - resyncing to group state');
+      }
+    }
+  }
+
+  // Pointer handlers for the pause button to detect long press (group pause)
+  _handlePausePointerDown(e) {
+    e.stopPropagation(); // prevent card-level hold_action from firing
+    if (!this.config?.shared_queue_id) return; // group pause only relevant for sync groups
+    this._pauseLongPressed = false;
+    this._pauseHoldTimer = setTimeout(() => {
+      this._pauseHoldTimer = null;
+      this._pauseLongPressed = true;
+      this._handleGroupPause();
+    }, 600);
+  }
+
+  _handlePausePointerUp(e) {
+    e.stopPropagation();
+    if (this._pauseHoldTimer) {
+      clearTimeout(this._pauseHoldTimer);
+      this._pauseHoldTimer = null;
+    }
+  }
+
+  // Long press on pause button: toggle group pause state and broadcast to all cards
+  _handleGroupPause() {
+    const nowGroupPaused = !this._groupPaused;
+    this._groupPaused = nowGroupPaused;
+    this._setPauseState(nowGroupPaused);
+    if (nowGroupPaused) {
+      this._pauseTimer();
+      this._log('🔒 Group PAUSED — broadcasting to sync group');
     } else {
       this._resumeTimer();
-      this._log('▶️ RESUMED slideshow - timer restarted');
+      this._log('🔓 Group RESUMED — broadcasting to sync group');
     }
-    // Broadcast pause state to all synced cards
     this._writeSharedQueueState(true);
+    this.requestUpdate();
   }
   
   // Handle debug button click - toggle debug mode dynamically

--- a/ha-media-card.js
+++ b/ha-media-card.js
@@ -4821,6 +4821,7 @@ class MediaCard extends LitElement {
     this._previousNavigationIndex = null;  // Saved navigation index before navigation
     this._isLoadingNext = false;  // Re-entrance guard for _loadNext()
     this._isManualNavigation = false; // V5.6.7: Track if navigation is user-initiated vs timer-driven
+    this._manualNavLoading = false;    // True from navigation commit until _onMediaLoaded/_onVideoCanPlay fires
     
     // V5.6.0: Play randomized option for panels
     this._playRandomized = false;      // Toggle for randomizing panel playback order
@@ -6284,6 +6285,12 @@ class MediaCard extends LitElement {
       this._fullMetadata = null;
       this._folderDisplayCache = null;
       
+      // Mark that a manual navigation is pending load — keeps _isManualNavigation
+      // semantics alive through the async image/video load phase so that any HA
+      // sync event arriving before _onMediaLoaded fires does not re-enter follower
+      // mode and suppress this card's own HA write.
+      if (this._isManualNavigation) this._manualNavLoading = true;
+
       await this._resolveMediaUrl();
       this.requestUpdate();
 
@@ -6299,10 +6306,11 @@ class MediaCard extends LitElement {
     this._refreshMetadata().catch(err => this._log('⚠️ Metadata refresh failed:', err));
   } catch (error) {
     console.error('[MediaCard] Error loading next media:', error);
+    this._manualNavLoading = false; // Safety: clear on exception
   } finally {
     // V5.6.7: Always clear re-entrance guard
     this._isLoadingNext = false;
-    // V5.6.7: Always clear manual navigation flag after navigation completes
+    // Clear the in-flight flag. _manualNavLoading covers the remaining async load phase.
     this._isManualNavigation = false;
   }
 }
@@ -6385,7 +6393,11 @@ class MediaCard extends LitElement {
     // V5: Clear cached full metadata when media changes
     this._fullMetadata = null;
     this._folderDisplayCache = null;
-    
+
+    // Mark that a manual navigation is pending load — keeps _isManualNavigation
+    // semantics alive through the async image/video load phase.
+    if (this._isManualNavigation) this._manualNavLoading = true;
+
     await this._resolveMediaUrl();
     this.requestUpdate();
     
@@ -6413,10 +6425,11 @@ class MediaCard extends LitElement {
     this._refreshMetadata().catch(err => this._log('⚠️ Metadata refresh failed:', err));
     } catch (error) {
       console.error('[MediaCard] Error loading previous media:', error);
+      this._manualNavLoading = false; // Safety: clear on exception
     } finally {
       // V5.6.7: Always clear re-entrance guard
       this._isLoadingNext = false;
-      // V5.6.7: Always clear manual navigation flag after navigation completes
+      // Clear the in-flight flag. _manualNavLoading covers the remaining async load phase.
       this._isManualNavigation = false;
     }
   }
@@ -8103,6 +8116,8 @@ class MediaCard extends LitElement {
   _onVideoCanPlay() {
     // V5.6.4: Timer uses simple counter, no timestamp needed
     this._log('🎬 Video ready - can play');
+    // Clear the manual-nav load-phase flag now that the media has committed to the DOM.
+    this._manualNavLoading = false;;
     
     // V5.8: Clear transient failure counter – video loaded successfully this time
     const itemId = this.currentMedia?.media_content_id;
@@ -8968,8 +8983,8 @@ class MediaCard extends LitElement {
     // If the user is actively pressing a button on this card, let the manual
     // navigation complete first.  We do NOT extend the follower window because
     // this card is in the middle of taking over as driver.
-    if (this._isManualNavigation) {
-      this._log('🔗 Manual nav in progress — not entering follower mode for this sync event');
+    if (this._isManualNavigation || this._manualNavLoading) {
+      this._log('🔗 Manual nav in progress (or pending load) — not entering follower mode for this sync event');
       return;
     }
     // Mark this card as a cross-device follower for 30 s.  While in follower mode,
@@ -9067,8 +9082,8 @@ class MediaCard extends LitElement {
     // _onHaSyncEvent already returned early so _crossDeviceFollowerUntil was not
     // re-set.  Nothing further to do here — the manual fetch will complete and
     // broadcast its own sync event to the driver.
-    if (this._isManualNavigation) {
-      this._log('\ud83d\uddb1\ufe0f Manual navigation in progress — ignoring incoming sync navigation');
+    if (this._isManualNavigation || this._manualNavLoading) {
+      this._log('\ud83d\uddb1\ufe0f Manual navigation in progress (or pending load) — ignoring incoming sync navigation');
       return;
     }
 
@@ -9247,10 +9262,14 @@ class MediaCard extends LitElement {
   }
 
   _onMediaLoaded(e) {
+    // Clear the manual-nav load-phase flag now that the media has committed to the DOM.
+    // This must happen before any early returns below so the flag is never left set.
+    this._manualNavLoading = false;
+
     // Log media loaded for images (videos log in _onVideoLoadStart)
     if (!this._isVideoFile(this.mediaUrl)) {
       this._log('Media loaded successfully:', this.mediaUrl);
-      
+
       // V5.6.7: Clear navigation flag now that image is loaded
       // This prevents timer from firing prematurely during transitions
       this._navigatingAway = false;

--- a/ha-media-card.js
+++ b/ha-media-card.js
@@ -8998,6 +8998,10 @@ class MediaCard extends LitElement {
     if (!id || event.key !== `ha-media-card:${id}` || !event.newValue) return;
     try {
       const data = JSON.parse(event.newValue);
+      // Mirror the 30s follower deferral that _onHaSyncEvent sets for cross-device events.
+      // Without this, _suppressSyncWriteUntil expires after 1s and the follower card
+      // writes its (identical) state to HA — wasted service calls and log noise.
+      this._crossDeviceFollowerUntil = Date.now() + 30000;
       this._applySharedQueueUpdate(data);
     } catch (_e) {}
   }
@@ -9007,6 +9011,10 @@ class MediaCard extends LitElement {
     const id = this.config?.shared_queue_id;
     if (!id || event.detail?.sharedQueueId !== id) return;
     if (event.detail?.sourceCardId === this._cardId) return; // ignore own writes
+    // Mirror the 30s follower deferral that _onHaSyncEvent sets for cross-device events.
+    // Without this, _suppressSyncWriteUntil expires after 1s and the follower card
+    // writes its (identical) state to HA — wasted service calls and log noise.
+    this._crossDeviceFollowerUntil = Date.now() + 30000;
     this._applySharedQueueUpdate(event.detail);
   }
 

--- a/ha-media-card.js
+++ b/ha-media-card.js
@@ -6078,12 +6078,19 @@ class MediaCard extends LitElement {
           // Cross-device reconnect grace: when restoring at the last queue slot the
           // driving device may be about to broadcast its next item.  Defer our own
           // provider fetch so we follow the driver rather than racing it with a
-          // different item that would briefly flash on-screen before the sync corrects.
+          // different item.  The grace window equals the slide interval + 3s buffer.
           if (this._crossDeviceProviderFetchUntil && Date.now() < this._crossDeviceProviderFetchUntil) {
             const remaining = this._crossDeviceProviderFetchUntil - Date.now();
             this._log(`⏳ Cross-device grace: deferring provider fetch ${remaining}ms`);
-            // Retry when the window expires; a sync event clears the flag early.
-            setTimeout(() => { if (!this._isLocallyPaused()) this._loadNext(); }, remaining + 50);
+            // Store the retry timer so it can be cancelled if a sync event arrives first.
+            if (this._crossDeviceGraceRetryTimer) clearTimeout(this._crossDeviceGraceRetryTimer);
+            this._crossDeviceGraceRetryTimer = setTimeout(() => {
+              this._crossDeviceGraceRetryTimer = null;
+              // Only retry if still at the end of the queue and no sync has advanced us.
+              if (!this._isLocallyPaused() && this.navigationIndex >= this.navigationQueue.length - 1) {
+                this._loadNext();
+              }
+            }, remaining + 50);
             return;
           }
           this._crossDeviceProviderFetchUntil = 0;
@@ -8752,12 +8759,17 @@ class MediaCard extends LitElement {
     this._log(`🔗 Shared queue restored: ${this.navigationQueue.length} items, index ${this.navigationIndex}`);
     // Cross-device reconnect grace period: when we restore at the last (or only) slot
     // the driver may be about to extend the queue and broadcast the next item.  Enter a
-    // short deferral window so the HA sync event arrives before we independently fetch a
-    // (potentially different) item from our own provider.  The window is cleared as soon
-    // as a sync event is received (in _applySharedQueueUpdate).
+    // deferral window equal to the configured advance interval + 3s safety buffer so
+    // that the driver's HA sync event arrives BEFORE we independently fetch a (potentially
+    // different) item from our own provider.  The window is cancelled as soon as a
+    // sync event is received (in _applySharedQueueUpdate).
     if (this._hasCrossDeviceSync() && this.navigationIndex >= this.navigationQueue.length - 1) {
-      this._crossDeviceProviderFetchUntil = Date.now() + 3000;
-      this._log('⏳ Cross-device grace period started (3s) — restored at end of shared queue');
+      const advanceSecs = this.config?.auto_advance_seconds ||
+                          this.config?.auto_advance_interval ||
+                          this.config?.auto_advance_duration || 10;
+      const graceMs = advanceSecs * 1000 + 3000;
+      this._crossDeviceProviderFetchUntil = Date.now() + graceMs;
+      this._log(`⏳ Cross-device grace period started (${(graceMs/1000).toFixed(0)}s) — restored at end of shared queue`);
     }
     return true;
   }
@@ -8873,6 +8885,10 @@ class MediaCard extends LitElement {
     // And clear the reconnect grace — user took control so local provider fetches
     // are welcome immediately.
     this._crossDeviceProviderFetchUntil = 0;
+    if (this._crossDeviceGraceRetryTimer) {
+      clearTimeout(this._crossDeviceGraceRetryTimer);
+      this._crossDeviceGraceRetryTimer = null;
+    }
     this._log(`👑 Force-claimed sync leadership for group '${id}' (displaced: ${prev})`);
   }
 
@@ -8971,8 +8987,13 @@ class MediaCard extends LitElement {
     if (eventTs) this._lastAppliedSyncAt = eventTs;
 
     // Clear reconnect grace period — the driver has broadcast its next item so
-    // we no longer need to defer provider fetches.
+    // we no longer need to defer provider fetches.  Also cancel any pending retry
+    // setTimeout so it doesn't fire and independently advance after the sync.
     this._crossDeviceProviderFetchUntil = 0;
+    if (this._crossDeviceGraceRetryTimer) {
+      clearTimeout(this._crossDeviceGraceRetryTimer);
+      this._crossDeviceGraceRetryTimer = null;
+    }
 
     const newIndex = Math.min(
       typeof data.currentIndex === 'number' ? data.currentIndex : 0,

--- a/ha-media-card.js
+++ b/ha-media-card.js
@@ -8545,6 +8545,15 @@ class MediaCard extends LitElement {
     // that a pause arriving simultaneously with a navigation doesn't get swallowed.
     if (this._suppressSyncWrite && !pauseIntent) {
       this._suppressSyncWrite = false;
+      // Also cancel any pending debounced DB write — it was queued before the sync
+      // event arrived and would still fire (bypassing _suppressSyncWrite) if not
+      // explicitly cancelled here.  Without this, a stale echo of the sender's own
+      // trimmed queue reaches the sender with a clamped index, corrupting the driver's
+      // navigation queue when the driver has since advanced to a different item.
+      if (this._syncWriteTimer) {
+        clearTimeout(this._syncWriteTimer);
+        this._syncWriteTimer = null;
+      }
       return;
     }
     this._suppressSyncWrite = false;
@@ -9001,8 +9010,14 @@ class MediaCard extends LitElement {
     // Use metadata from the sender if provided — avoids a round-trip fetch and
     // works even when this card has no media-index configured.
     this._pendingMetadata = data.currentMetadata || null;
-    // Suppress the outgoing write that would otherwise echo this event back
+    // Suppress the outgoing write that would otherwise echo this event back.
+    // Also cancel any in-flight debounced write immediately — defence-in-depth so
+    // the timer can't fire between now and when _writeSharedQueueState is next called.
     this._suppressSyncWrite = true;
+    if (this._syncWriteTimer) {
+      clearTimeout(this._syncWriteTimer);
+      this._syncWriteTimer = null;
+    }
     // Mark navigation in progress so the local slideshow timer doesn't fire a
     // competing _loadNext() while the sync-driven URL resolution is in flight.
     // _navigatingAway is cleared by _onMediaLoaded / _onVideoCanPlay as normal.

--- a/ha-media-card.js
+++ b/ha-media-card.js
@@ -7354,6 +7354,12 @@ class MediaCard extends LitElement {
     // If expectedNavigationIndex is provided and doesn't match current pending index, abort
     if (expectedNavigationIndex !== undefined && this._pendingNavigationIndex !== expectedNavigationIndex) {
       this._log(`⏭️ Skipping stale media resolution (expected: ${expectedNavigationIndex}, current: ${this._pendingNavigationIndex})`);
+      // Clear the navigation-in-progress flag when nothing else has claimed a pending
+      // path (i.e. no sync nav or newer _loadNext() is in flight). Without this,
+      // a stale return from a _loadNext() call that was superseded by a rapid sync
+      // burst can leave _navigatingAway=true permanently, causing the slideshow
+      // timer to log "Timer skipped" indefinitely.
+      if (!this._pendingMediaPath) this._navigatingAway = false;
       return;
     }
     
@@ -8868,6 +8874,10 @@ class MediaCard extends LitElement {
     this._pendingMetadata = data.currentMetadata || null;
     // Suppress the outgoing write that would otherwise echo this event back
     this._suppressSyncWrite = true;
+    // Mark navigation in progress so the local slideshow timer doesn't fire a
+    // competing _loadNext() while the sync-driven URL resolution is in flight.
+    // _navigatingAway is cleared by _onMediaLoaded / _onVideoCanPlay as normal.
+    this._navigatingAway = true;
     this._resolveMediaUrl();
     this.requestUpdate();
     // For media-index cards: kick off a background fetch to get fresher/fuller

--- a/ha-media-card.js
+++ b/ha-media-card.js
@@ -4905,14 +4905,8 @@ class MediaCard extends LitElement {
       this._startClockTimer();
     }
     
-    // V5: Restart auto-refresh if it was running before disconnect
-    // Only restart if we have a provider, currentMedia, and auto_advance is configured
-    if (this.provider && this.currentMedia && this.config.auto_advance_seconds > 0) {
-      this._log('🔄 Reconnected - restarting auto-refresh timer');
-      this._setupAutoRefresh();
-    }
-
-    // Shared queue: register event listeners (cross-device HA events + same-device)
+    // Shared queue: register event listeners and claim leadership BEFORE the reconnect
+    // auto-refresh below, so _setupAutoRefresh() correctly sees this card as leader.
     this._subscribeToSyncEvents();
 
     // Leader election: try to become the timer leader for this sync group.
@@ -4920,16 +4914,25 @@ class MediaCard extends LitElement {
     this._tryClaimLeadership();
 
     // Listen for the vacancy event fired when the leader disconnects, so a follower
-    // can step up and start its own timer.
-    this._leaderVacatedHandler = (e) => {
-      if (e.detail?.sharedQueueId !== this.config?.shared_queue_id) return;
-      const claimed = this._tryClaimLeadership();
-      if (claimed) {
-        this._log('👑 Stepping up as leader after vacancy — starting timer');
-        this._setupAutoRefresh();
-      }
-    };
-    window.addEventListener('ha-media-card-leader-vacated', this._leaderVacatedHandler);
+    // can step up and start its own timer. Only registered when shared_queue_id is set.
+    if (this.config?.shared_queue_id) {
+      this._leaderVacatedHandler = (e) => {
+        if (e.detail?.sharedQueueId !== this.config?.shared_queue_id) return;
+        const claimed = this._tryClaimLeadership();
+        if (claimed) {
+          this._log('👑 Stepping up as leader after vacancy — starting timer');
+          this._setupAutoRefresh();
+        }
+      };
+      window.addEventListener('ha-media-card-leader-vacated', this._leaderVacatedHandler);
+    }
+
+    // V5: Restart auto-refresh if it was running before disconnect
+    // Only restart if we have a provider, currentMedia, and auto_advance is configured
+    if (this.provider && this.currentMedia && this.config.auto_advance_seconds > 0) {
+      this._log('🔄 Reconnected - restarting auto-refresh timer');
+      this._setupAutoRefresh();
+    }
 
     // Shared queue: if reconnecting (provider already exists), sync state from
     // media-index or localStorage to pick up where the other card left off
@@ -8117,7 +8120,7 @@ class MediaCard extends LitElement {
     // V5.6.4: Timer uses simple counter, no timestamp needed
     this._log('🎬 Video ready - can play');
     // Clear the manual-nav load-phase flag now that the media has committed to the DOM.
-    this._manualNavLoading = false;;
+    this._manualNavLoading = false;
     
     // V5.8: Clear transient failure counter – video loaded successfully this time
     const itemId = this.currentMedia?.media_content_id;
@@ -19596,7 +19599,7 @@ Tip: Check your Home Assistant media folder in Settings > System > Storage`;
                 }}
                 placeholder="e.g. main-slideshow"
               />
-              <div class="help-text">Optional. Cards with the same ID share their queue and position across views on the same device. Leave empty to disable.</div>
+              <div class="help-text">Optional. Cards with the same ID share their queue and position — across views, tabs, and devices. Same-device sync uses browser events; cross-device sync (phones, tablets, other browsers) requires Media Index. Leave empty to disable.</div>
             </div>
           </div>
         </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-media-card",
-  "version": "5.9.0",
+  "version": "5.10.0",
   "description": "Home Assistant dashboard card for displaying media with slideshow, favorites, and metadata",
   "type": "module",
   "scripts": {

--- a/src/editor/media-card-editor.js
+++ b/src/editor/media-card-editor.js
@@ -3414,6 +3414,25 @@ Tip: Check your Home Assistant media folder in Settings > System > Storage`;
               <div class="help-text">Check for new files every N seconds (0 = disabled). Single media: reloads image URL. Folder mode: checks for new files and refreshes queue if at newest position.</div>
             </div>
           </div>
+
+          <div class="config-row">
+            <label>Shared Queue ID</label>
+            <div>
+              <input
+                type="text"
+                .value=${this._config.shared_queue_id || ''}
+                @input=${(e) => {
+                  const val = e.target.value.trim();
+                  this._config = val
+                    ? { ...this._config, shared_queue_id: val }
+                    : (() => { const c = { ...this._config }; delete c.shared_queue_id; return c; })();
+                  this.dispatchEvent(new CustomEvent('config-changed', { detail: { config: this._config } }));
+                }}
+                placeholder="e.g. main-slideshow"
+              />
+              <div class="help-text">Optional. Cards with the same ID share their queue and position across views on the same device. Leave empty to disable.</div>
+            </div>
+          </div>
         </div>
 
         ${mediaSourceType === 'folder' ? html`

--- a/src/editor/media-card-editor.js
+++ b/src/editor/media-card-editor.js
@@ -3430,7 +3430,7 @@ Tip: Check your Home Assistant media folder in Settings > System > Storage`;
                 }}
                 placeholder="e.g. main-slideshow"
               />
-              <div class="help-text">Optional. Cards with the same ID share their queue and position across views on the same device. Leave empty to disable.</div>
+              <div class="help-text">Optional. Cards with the same ID share their queue and position — across views, tabs, and devices. Same-device sync uses browser events; cross-device sync (phones, tablets, other browsers) requires Media Index. Leave empty to disable.</div>
             </div>
           </div>
         </div>

--- a/src/ui/media-card.js
+++ b/src/ui/media-card.js
@@ -275,16 +275,11 @@ export class MediaCard extends LitElement {
       this._setupAutoRefresh();
     }
 
-    // Shared queue: listen for navigation events from other card instances
-    if (this.config?.shared_queue_id) {
-      this._storageEventHandler = this._onStorageEvent.bind(this);
-      window.addEventListener('storage', this._storageEventHandler);
-      this._queueSyncEventHandler = this._onQueueSyncEvent.bind(this);
-      window.addEventListener('ha-media-card-sync', this._queueSyncEventHandler);
-    }
+    // Shared queue: register event listeners (cross-device HA events + same-device)
+    this._subscribeToSyncEvents();
 
-    // Shared queue: if reconnecting (provider already exists), sync from localStorage
-    // to pick up everything the other card navigated while this card was hidden
+    // Shared queue: if reconnecting (provider already exists), sync state from
+    // media-index or localStorage to pick up where the other card left off
     if (this.provider && this.config?.shared_queue_id) {
       this._syncFromSharedQueueOnReconnect();
     }
@@ -298,15 +293,8 @@ export class MediaCard extends LitElement {
     // NEW: Cleanup kiosk mode monitoring
     this._cleanupKioskModeMonitoring();
     
-    // Shared queue: remove storage event listener
-    if (this._storageEventHandler) {
-      window.removeEventListener('storage', this._storageEventHandler);
-      this._storageEventHandler = null;
-    }
-    if (this._queueSyncEventHandler) {
-      window.removeEventListener('ha-media-card-sync', this._queueSyncEventHandler);
-      this._queueSyncEventHandler = null;
-    }
+    // Shared queue: remove all event listeners and cancel pending debounced write
+    this._unsubscribeFromSyncEvents();
     
     // V5.6: Cleanup viewport height observer
     this._cleanupDynamicViewportHeight();
@@ -578,7 +566,11 @@ export class MediaCard extends LitElement {
     if (this._debugMode || window.location.hostname === 'localhost') {
       // Prefix all logs with card ID for debugging
       const prefix = `[${this._cardId}]`;
-      const message = args.join(' ');
+      // Strip auth tokens (e.g. Synology authSig) so logs stay readable when pasting
+      const sanitizedArgs = args.map(a =>
+        typeof a === 'string' ? a.replace(/([?&])authSig=[^&\s]*/gi, '$1authSig=[…]') : a
+      );
+      const message = sanitizedArgs.join(' ');
       
       // Throttle certain frequent messages to avoid spam
       const throttlePatterns = [
@@ -603,7 +595,7 @@ export class MediaCard extends LitElement {
         this._lastLogTime[message] = now;
       }
       
-      console.log(prefix, ...args);
+      console.log(prefix, ...sanitizedArgs);
     }
   }
 
@@ -1122,7 +1114,7 @@ export class MediaCard extends LitElement {
       if (success) {
         // Shared queue takes priority over local history when configured — it holds the
         // freshest cross-card state (what the other card was showing when this view was hidden).
-        const restoredFromShared = this._tryRestoreFromSharedQueue();
+        const restoredFromShared = await this._tryRestoreFromSharedQueue();
 
         if (restoredFromShared) {
           // Queue and index already set — jump directly to the saved item
@@ -1416,6 +1408,9 @@ export class MediaCard extends LitElement {
           this._pendingNavigationIndex = 0;
         } else {
           this._log('Navigation queue exhausted, loading from provider');
+          // Capture generation before any awaits so we can detect if a sync event
+          // arrived from another card while we were waiting for the provider.
+          const _syncGenBefore = this._syncNavGeneration || 0;
           let item = await this.provider.getNext();
         
           if (item) {
@@ -1485,6 +1480,16 @@ export class MediaCard extends LitElement {
                 // forward to the new item, not staying at the current position
                 nextIndex = this.navigationQueue.length - 1;
               }
+
+              // Sync mode: if another card already broadcast a new item while we were awaiting
+              // the provider (same-window CustomEvent fires mid-await), follow that card instead.
+              if ((this._syncNavGeneration || 0) > _syncGenBefore) {
+                this._log('🔗 Another synced card broadcast first — following sync navigation, discarding locally-fetched item');
+                return;
+              }
+              // We are the "first" card — broadcast our new item immediately so other
+              // same-window cards adopt it synchronously before they exit their own awaits.
+              this._earlyBroadcastSyncState(nextIndex);
             }
           } else {
             // No more items available from provider, wrap to beginning with fresh query
@@ -3819,102 +3824,296 @@ export class MediaCard extends LitElement {
     }
   }
 
-  // Shared Queue: write current queue state to localStorage and broadcast to same-window instances
-  _writeSharedQueueState() {
+  // ─── Shared Queue ──────────────────────────────────────────────────────────
+  // Two transport layers, selected automatically:
+  //   • Cross-device (media-index configured): service calls + HA websocket events
+  //   • Single-device fallback: localStorage + window CustomEvent
+
+  // Return the media_index entity_id configured on this card, or null.
+  _getMediaIndexEntityId() {
+    return this.config?.media_index?.entity_id || null;
+  }
+
+  // Is cross-device sync available?
+  _hasCrossDeviceSync() {
+    return !!(this.config?.shared_queue_id && this._getMediaIndexEntityId() && this.hass);
+  }
+
+  // ── Write path ──────────────────────────────────────────────────────────────
+  // Called after every navigation commit. Debounced to avoid hammering the service.
+  // pauseIntent=true ONLY for user-initiated pause/resume actions — navigation writes
+  // must NOT set it, otherwise Device B's navigation will overwrite Device A's local
+  // pause state.
+  _writeSharedQueueState(pauseIntent = false) {
     const id = this.config?.shared_queue_id;
     if (!id || !this.navigationQueue?.length) return;
+
+    // Echo-prevention: skip the write that would bounce an incoming navigation sync
+    // back to the sender. BUT always allow explicit pause/resume writes through so
+    // that a pause arriving simultaneously with a navigation doesn't get swallowed.
+    if (this._suppressSyncWrite && !pauseIntent) {
+      this._suppressSyncWrite = false;
+      return;
+    }
+    this._suppressSyncWrite = false;
+
+    // Always write localStorage for instant same-device sync
     try {
       const data = {
         queue: this.navigationQueue.map(item => item.media_content_id),
         currentIndex: this.navigationIndex,
+        // Include metadata for the current item so receiving cards can display it
+        // immediately without needing a separate media-index fetch.
+        currentMetadata: this._currentMetadata || this._pendingMetadata || null,
+        isPaused: this._isPaused,
+        pauseIntent,
         updatedAt: Date.now(),
-        sourceCardId: this._cardId  // so listeners can ignore their own writes
+        sourceCardId: this._cardId,
       };
       localStorage.setItem(`ha-media-card:${id}`, JSON.stringify(data));
-      // Also broadcast within same window (storage event doesn't fire for same-window writes)
+      // Broadcast within same window (storage event doesn't fire for same-window writes)
       window.dispatchEvent(new CustomEvent('ha-media-card-sync', { detail: { sharedQueueId: id, ...data } }));
-    } catch (_e) {
-      // localStorage may be unavailable in some environments
+    } catch (_e) {}
+
+    // Cross-device: debounced service call.
+    // Accumulate pauseIntent across debounce resets so that a pause write that arrives
+    // just before a navigation write doesn't silently lose the intent.
+    if (this._hasCrossDeviceSync()) {
+      this._pendingSyncPauseIntent = (this._pendingSyncPauseIntent || false) || pauseIntent;
+      if (this._syncWriteTimer) clearTimeout(this._syncWriteTimer);
+      this._syncWriteTimer = setTimeout(() => {
+        this._syncWriteTimer = null;
+        const intent = this._pendingSyncPauseIntent || false;
+        this._pendingSyncPauseIntent = false;
+        this._writeSharedQueueStateToMediaIndex(intent);
+      }, 500);
     }
   }
 
-  // Shared Queue: called on reconnect (provider already exists) to sync queue state
-  // from localStorage so this card picks up where the other card left off
-  _syncFromSharedQueueOnReconnect() {
+  async _writeSharedQueueStateToMediaIndex(pauseIntent = false) {
     const id = this.config?.shared_queue_id;
-    if (!id) return;
+    if (!id || !this.navigationQueue?.length) return;
     try {
-      const raw = localStorage.getItem(`ha-media-card:${id}`);
-      if (!raw) return;
-      const data = JSON.parse(raw);
-      if (!Array.isArray(data.queue) || !data.queue.length) return;
-      const newIndex = Math.min(
-        typeof data.currentIndex === 'number' ? data.currentIndex : 0,
-        data.queue.length - 1
-      );
-      const newPath = data.queue[newIndex];
-      // Always restore the full queue so back-navigation history is preserved
-      this.navigationQueue = data.queue.map(mediaId => ({
-        media_content_id: mediaId,
-        media_content_type: MediaUtils.detectFileType(mediaId) || 'image',
-        title: mediaId.split('/').pop() || mediaId,
-        metadata: null
-      }));
-      this.navigationIndex = newIndex;
-      this._log(`🔗 Shared queue synced on reconnect: ${this.navigationQueue.length} items, index ${newIndex}`);
-      // Navigate to the current image if it differs from what we were last showing
-      if (newPath !== this._currentMediaPath) {
-        const item = this.navigationQueue[newIndex];
-        this.currentMedia = item;
-        this._pendingNavigationIndex = newIndex;
-        this._pendingMediaPath = newPath;
-        this._pendingMetadata = null;
-        this._resolveMediaUrl();
-        this.requestUpdate();
-      }
-    } catch (_e) {}
+      const entityId = this._getMediaIndexEntityId();
+      const queue = this.navigationQueue.map(item => item.media_content_id);
+      await this.hass.connection.sendMessagePromise({
+        type: 'call_service',
+        domain: 'media_index',
+        service: 'update_sync_state',
+        service_data: {
+          sync_group: id,
+          queue,
+          current_index: this.navigationIndex,
+          is_paused: this._isPaused,
+          pause_intent: pauseIntent,
+          source_card_id: this._cardId,
+          current_metadata: JSON.stringify(this._currentMetadata || this._pendingMetadata || null),
+        },
+        target: { entity_id: entityId },
+      });
+      this._log(`🔗 Sync state written to media_index for group '${id}'`);
+    } catch (e) {
+      this._log('⚠️ Failed to write shared queue to media_index:', e);
+    }
   }
 
-  // Shared Queue: restore queue from localStorage on load
-  // Returns true if queue was restored (caller should skip normal provider init)
-  _tryRestoreFromSharedQueue() {
+  // ── Read path (first load) ──────────────────────────────────────────────────
+  // Returns true and populates navigationQueue/navigationIndex if state was found.
+  async _tryRestoreFromSharedQueue() {
     const id = this.config?.shared_queue_id;
     if (!id) return false;
+
+    // Cross-device: fetch from media-index (authoritative, any device may have written it)
+    if (this._hasCrossDeviceSync()) {
+      try {
+        const entityId = this._getMediaIndexEntityId();
+        const resp = await this.hass.connection.sendMessagePromise({
+          type: 'call_service',
+          domain: 'media_index',
+          service: 'get_sync_state',
+          service_data: { sync_group: id },
+          target: { entity_id: entityId },
+          return_response: true,
+        });
+        const data = resp?.response;
+        if (data?.found && Array.isArray(data.queue) && data.queue.length) {
+          return this._applyRestoredState(data.queue, data.current_index);
+        }
+      } catch (e) {
+        this._log('⚠️ Could not fetch sync state from media_index, falling back to localStorage:', e);
+      }
+    }
+
+    // Single-device fallback: localStorage
     try {
       const raw = localStorage.getItem(`ha-media-card:${id}`);
       if (!raw) return false;
       const data = JSON.parse(raw);
       if (!Array.isArray(data.queue) || !data.queue.length) return false;
-      this.navigationQueue = data.queue.map(mediaId => ({
-        media_content_id: mediaId,
-        media_content_type: MediaUtils.detectFileType(mediaId) || 'image',
-        title: mediaId.split('/').pop() || mediaId,
-        metadata: null
-      }));
-      this.navigationIndex = Math.min(
-        typeof data.currentIndex === 'number' ? data.currentIndex : 0,
-        this.navigationQueue.length - 1
-      );
-      this._log(`🔗 Shared queue restored: ${this.navigationQueue.length} items, index ${this.navigationIndex}`);
-      return true;
+      return this._applyRestoredState(data.queue, data.currentIndex);
     } catch (_e) {
       return false;
     }
   }
 
-  // Shared Queue: handle storage events from OTHER browser tabs/windows
+  // ── Read path (reconnect) ───────────────────────────────────────────────────
+  async _syncFromSharedQueueOnReconnect() {
+    const id = this.config?.shared_queue_id;
+    if (!id) return;
+
+    let queue = null, currentIndex = 0;
+
+    // Cross-device: fetch from media-index
+    if (this._hasCrossDeviceSync()) {
+      try {
+        const entityId = this._getMediaIndexEntityId();
+        const resp = await this.hass.connection.sendMessagePromise({
+          type: 'call_service',
+          domain: 'media_index',
+          service: 'get_sync_state',
+          service_data: { sync_group: id },
+          target: { entity_id: entityId },
+          return_response: true,
+        });
+        const data = resp?.response;
+        if (data?.found && Array.isArray(data.queue) && data.queue.length) {
+          queue = data.queue;
+          currentIndex = typeof data.current_index === 'number' ? data.current_index : 0;
+        }
+      } catch (e) {
+        this._log('⚠️ Could not fetch sync state from media_index for reconnect:', e);
+      }
+    }
+
+    // Fallback: localStorage
+    if (!queue) {
+      try {
+        const raw = localStorage.getItem(`ha-media-card:${id}`);
+        if (raw) {
+          const data = JSON.parse(raw);
+          if (Array.isArray(data.queue) && data.queue.length) {
+            queue = data.queue;
+            currentIndex = typeof data.currentIndex === 'number' ? data.currentIndex : 0;
+          }
+        }
+      } catch (_e) {}
+    }
+
+    if (!queue) return;
+    const newIndex = Math.min(currentIndex, queue.length - 1);
+    const newPath = queue[newIndex];
+    this.navigationQueue = queue.map(mediaId => ({
+      media_content_id: mediaId,
+      media_content_type: MediaUtils.detectFileType(mediaId) || 'image',
+      title: mediaId.split('/').pop() || mediaId,
+      metadata: null,
+    }));
+    this.navigationIndex = newIndex;
+    this._log(`🔗 Shared queue synced on reconnect: ${this.navigationQueue.length} items, index ${newIndex}`);
+    if (newPath !== this._currentMediaPath) {
+      const item = this.navigationQueue[newIndex];
+      this.currentMedia = item;
+      this._pendingNavigationIndex = newIndex;
+      this._pendingMediaPath = newPath;
+      this._pendingMetadata = null;
+      this._resolveMediaUrl();
+      this.requestUpdate();
+    }
+  }
+
+  // ── Shared helper ───────────────────────────────────────────────────────────
+  _applyRestoredState(queue, rawIndex) {
+    this.navigationQueue = queue.map(mediaId => ({
+      media_content_id: mediaId,
+      media_content_type: MediaUtils.detectFileType(mediaId) || 'image',
+      title: mediaId.split('/').pop() || mediaId,
+      metadata: null,
+    }));
+    this.navigationIndex = Math.min(
+      typeof rawIndex === 'number' ? rawIndex : 0,
+      this.navigationQueue.length - 1
+    );
+    this._log(`🔗 Shared queue restored: ${this.navigationQueue.length} items, index ${this.navigationIndex}`);
+    return true;
+  }
+
+  // ── Event listeners ─────────────────────────────────────────────────────────
+  // Subscribe to HA websocket events (cross-device) and window CustomEvent (same-device).
+  _subscribeToSyncEvents() {
+    const id = this.config?.shared_queue_id;
+    if (!id) return;
+
+    // Same-window CustomEvent (instant, no round-trip)
+    this._queueSyncEventHandler = this._onQueueSyncEvent.bind(this);
+    window.addEventListener('ha-media-card-sync', this._queueSyncEventHandler);
+
+    // Same-device cross-tab via storage event
+    this._storageEventHandler = this._onStorageEvent.bind(this);
+    window.addEventListener('storage', this._storageEventHandler);
+
+    // Cross-device: subscribe to HA bus event fired by media_index.update_sync_state
+    if (this._hasCrossDeviceSync()) {
+      this._haSyncUnsubscribe = this.hass.connection.subscribeEvents(
+        (event) => this._onHaSyncEvent(event),
+        'media_index.sync_updated'
+      ).catch(e => {
+        this._log('⚠️ Failed to subscribe to media_index.sync_updated:', e);
+        this._haSyncUnsubscribe = null;
+      });
+    }
+  }
+
+  _unsubscribeFromSyncEvents() {
+    if (this._storageEventHandler) {
+      window.removeEventListener('storage', this._storageEventHandler);
+      this._storageEventHandler = null;
+    }
+    if (this._queueSyncEventHandler) {
+      window.removeEventListener('ha-media-card-sync', this._queueSyncEventHandler);
+      this._queueSyncEventHandler = null;
+    }
+    if (this._haSyncUnsubscribe) {
+      // subscribeEvents returns a Promise<unsubscribe fn>; handle both cases
+      Promise.resolve(this._haSyncUnsubscribe).then(unsub => { if (unsub) unsub(); }).catch(() => {});
+      this._haSyncUnsubscribe = null;
+    }
+    if (this._syncWriteTimer) {
+      clearTimeout(this._syncWriteTimer);
+      this._syncWriteTimer = null;
+    }
+  }
+
+  // HA websocket event from media_index (cross-device)
+  _onHaSyncEvent(event) {
+    const id = this.config?.shared_queue_id;
+    const data = event.data;
+    if (!id || data?.sync_group !== id) return;
+    // Ignore events we ourselves wrote (media_index echoes back to all subscribers)
+    if (data?.source_card_id === this._cardId) return;
+    let currentMetadata = null;
+    if (data.current_metadata) {
+      try { currentMetadata = JSON.parse(data.current_metadata); } catch (_e) {}
+    }
+    this._applySharedQueueUpdate({
+      queue: data.queue,
+      currentIndex: data.current_index,
+      currentMetadata,
+      isPaused: data.is_paused,
+      pauseIntent: data.pause_intent,
+    });
+  }
+
+  // storage event (cross-tab, same device)
   _onStorageEvent(event) {
     const id = this.config?.shared_queue_id;
     if (!id || event.key !== `ha-media-card:${id}` || !event.newValue) return;
     try {
       const data = JSON.parse(event.newValue);
       this._applySharedQueueUpdate(data);
-    } catch (_e) {
-      // ignore malformed data
-    }
+    } catch (_e) {}
   }
 
-  // Shared Queue: handle CustomEvents from other card instances in the same window
+  // window CustomEvent (same window, instant)
   _onQueueSyncEvent(event) {
     const id = this.config?.shared_queue_id;
     if (!id || event.detail?.sharedQueueId !== id) return;
@@ -3922,7 +4121,26 @@ export class MediaCard extends LitElement {
     this._applySharedQueueUpdate(event.detail);
   }
 
-  // Shared Queue: shared logic for applying an incoming queue update
+  // Broadcast the new queue state (with a specific index) without waiting for image load.
+  // Used when the local provider returns a new item so that same-window cards receive
+  // it synchronously (before their own provider awaits complete) and follow along.
+  _earlyBroadcastSyncState(nextIndex) {
+    const id = this.config?.shared_queue_id;
+    if (!id) return;
+    try {
+      const data = {
+        queue: this.navigationQueue.map(qi => qi.media_content_id),
+        currentIndex: nextIndex,
+        isPaused: this._isPaused,
+        updatedAt: Date.now(),
+        sourceCardId: this._cardId,
+      };
+      localStorage.setItem(`ha-media-card:${id}`, JSON.stringify(data));
+      window.dispatchEvent(new CustomEvent('ha-media-card-sync', { detail: { sharedQueueId: id, ...data } }));
+    } catch (_e) {}
+  }
+
+  // Apply an incoming queue update from any transport
   _applySharedQueueUpdate(data) {
     if (!Array.isArray(data.queue) || !data.queue.length) return;
     const newIndex = Math.min(
@@ -3930,23 +4148,74 @@ export class MediaCard extends LitElement {
       data.queue.length - 1
     );
     const newPath = data.queue[newIndex];
-    if (newPath === this._currentMediaPath) return; // already showing this
+
+    // Increment generation counter so any _loadNext() suspended in an await will
+    // see that a sync event took priority and should not overwrite our navigation.
+    this._syncNavGeneration = (this._syncNavGeneration || 0) + 1;
+
+    // Apply pause state ONLY when the sender explicitly toggled it (pauseIntent).
+    // Navigation syncs carry the sender's current isPaused as context (for new devices
+    // joining the group) but must NOT overwrite the local pause state — otherwise
+    // Device B playing and Device A paused leads to Device B's navigation writes
+    // continuously unpausing Device A.
+    if (data.pauseIntent === true && typeof data.isPaused === 'boolean' && data.isPaused !== this._isPaused) {
+      this._setPauseState(data.isPaused);
+      if (data.isPaused) { this._pauseTimer(); } else { this._resumeTimer(); }
+    }
+
+    // Skip navigation if we are already showing this path OR already navigating to it.
+    // The _pendingMediaPath check prevents duplicate navigation when the same update
+    // arrives via multiple transports (CustomEvent then HA event ~500ms later) before
+    // the image has fully loaded and _currentMediaPath has been committed.
+    // HOWEVER: a second broadcast for the same path may carry metadata that the first
+    // (early) broadcast lacked — apply it even if we skip navigation.
+    if (newPath === this._currentMediaPath || newPath === this._pendingMediaPath) {
+      if (data.currentMetadata) {
+        if (this._pendingMediaPath !== null) {
+          // Still loading — merge into pending so it applies when image loads
+          this._pendingMetadata = { ...(this._pendingMetadata || {}), ...data.currentMetadata };
+        } else {
+          // Already showing — apply directly and re-render
+          this._currentMetadata = { ...(this._currentMetadata || {}), ...data.currentMetadata };
+          this.requestUpdate();
+        }
+      }
+      return;
+    }
     this._log(`🔗 Shared queue sync: navigating to index ${newIndex}`);
+
+    // Reset the auto-advance timer immediately. Without this, the old timer (which may
+    // be only seconds from expiring) would fire before the incoming image loads, call
+    // _loadNext(), exhaust the queue, fetch a DIFFERENT item and broadcast it — causing
+    // a cascade where each of the N cards adds a new item in rapid succession.
+    // _setupAutoRefresh clears the old interval and starts a fresh full-duration one.
+    if (!this._isPaused) {
+      this._setupAutoRefresh();
+    }
     this.navigationQueue = data.queue.map(mediaId => ({
       media_content_id: mediaId,
       media_content_type: MediaUtils.detectFileType(mediaId) || 'image',
       title: mediaId.split('/').pop() || mediaId,
-      metadata: null
+      metadata: null,
     }));
     this.navigationIndex = newIndex;
     const item = this.navigationQueue[newIndex];
     this.currentMedia = item;
     this._pendingNavigationIndex = newIndex;
     this._pendingMediaPath = newPath;
-    this._pendingMetadata = null;
+    // Use metadata from the sender if provided — avoids a round-trip fetch and
+    // works even when this card has no media-index configured.
+    this._pendingMetadata = data.currentMetadata || null;
+    // Suppress the outgoing write that would otherwise echo this event back
+    this._suppressSyncWrite = true;
     this._resolveMediaUrl();
     this.requestUpdate();
+    // For media-index cards: kick off a background fetch to get fresher/fuller
+    // metadata (sender may have had stale data too). No-op for non-media-index cards.
+    this._refreshMetadata().catch(err => this._log('⚠️ Sync metadata refresh failed:', err));
   }
+
+  // ── End Shared Queue ────────────────────────────────────────────────────────
 
   // V4: Keyboard navigation handler
   _handleKeyDown(e) {
@@ -3984,7 +4253,8 @@ export class MediaCard extends LitElement {
       } else {
         this._setupAutoRefresh();
       }
-      
+      // Broadcast pause state to all synced cards
+      this._writeSharedQueueState(true);
       this.requestUpdate();
     }
   }
@@ -4005,6 +4275,8 @@ export class MediaCard extends LitElement {
     } else {
       this._resumeTimer();
     }
+    // Broadcast pause state to all synced cards
+    this._writeSharedQueueState(true);
   }
   
   // V4: Pause state management (copied from ha-media-card.js)
@@ -4267,7 +4539,7 @@ export class MediaCard extends LitElement {
       
       // Priority 3: Filesystem date as last fallback
       if (!date && metadata.date) {
-        date = metadata.date;
+        date = (metadata.date instanceof Date) ? metadata.date : new Date(metadata.date);
       }
       
       if (date && !isNaN(date.getTime())) {
@@ -5681,6 +5953,8 @@ export class MediaCard extends LitElement {
       this._resumeTimer();
       this._log('▶️ RESUMED slideshow - timer restarted');
     }
+    // Broadcast pause state to all synced cards
+    this._writeSharedQueueState(true);
   }
   
   // Handle debug button click - toggle debug mode dynamically

--- a/src/ui/media-card.js
+++ b/src/ui/media-card.js
@@ -4177,6 +4177,12 @@ export class MediaCard extends LitElement {
       if (data.isPaused) { this._pauseTimer(); } else { this._resumeTimer(); }
     }
 
+    // If this card is still paused after processing the intent, do not follow navigation
+    // from peers. The user intentionally paused this card; auto-advance from other running
+    // cards should not override that. A resume (pauseIntent=true, isPaused=false) will have
+    // already cleared _isPaused above, so the card resumes and still navigates.
+    if (this._isPaused) return;
+
     // Skip navigation if we are already showing this path OR already navigating to it.
     // The _pendingMediaPath check prevents duplicate navigation when the same update
     // arrives via multiple transports (CustomEvent then HA event ~500ms later) before

--- a/src/ui/media-card.js
+++ b/src/ui/media-card.js
@@ -3908,6 +3908,7 @@ export class MediaCard extends LitElement {
           pause_intent: pauseIntent,
           source_card_id: this._cardId,
           current_metadata: JSON.stringify(this._currentMetadata || this._pendingMetadata || null),
+          written_at: Date.now(),
         },
         target: { entity_id: entityId },
       });
@@ -4100,6 +4101,7 @@ export class MediaCard extends LitElement {
       currentMetadata,
       isPaused: data.is_paused,
       pauseIntent: data.pause_intent,
+      updatedAt: data.written_at || 0,
     });
   }
 
@@ -4143,6 +4145,18 @@ export class MediaCard extends LitElement {
   // Apply an incoming queue update from any transport
   _applySharedQueueUpdate(data) {
     if (!Array.isArray(data.queue) || !data.queue.length) return;
+
+    // Reject stale events that arrive out of order. Each write includes a
+    // written_at/updatedAt timestamp (ms epoch). If this event is older than the
+    // most recent one already applied, discard it — it is a delayed HA event from
+    // a previous navigation that arrived after a newer write already advanced us.
+    const eventTs = data.updatedAt || 0;
+    if (eventTs && eventTs < (this._lastAppliedSyncAt || 0)) {
+      this._log(`⏩ Discarding stale sync event (ts=${eventTs}, last=${this._lastAppliedSyncAt})`);
+      return;
+    }
+    if (eventTs) this._lastAppliedSyncAt = eventTs;
+
     const newIndex = Math.min(
       typeof data.currentIndex === 'number' ? data.currentIndex : 0,
       data.queue.length - 1

--- a/src/ui/media-card.js
+++ b/src/ui/media-card.js
@@ -274,6 +274,20 @@ export class MediaCard extends LitElement {
       this._log('🔄 Reconnected - restarting auto-refresh timer');
       this._setupAutoRefresh();
     }
+
+    // Shared queue: listen for navigation events from other card instances
+    if (this.config?.shared_queue_id) {
+      this._storageEventHandler = this._onStorageEvent.bind(this);
+      window.addEventListener('storage', this._storageEventHandler);
+      this._queueSyncEventHandler = this._onQueueSyncEvent.bind(this);
+      window.addEventListener('ha-media-card-sync', this._queueSyncEventHandler);
+    }
+
+    // Shared queue: if reconnecting (provider already exists), sync from localStorage
+    // to pick up everything the other card navigated while this card was hidden
+    if (this.provider && this.config?.shared_queue_id) {
+      this._syncFromSharedQueueOnReconnect();
+    }
   }
 
   disconnectedCallback() {
@@ -283,6 +297,16 @@ export class MediaCard extends LitElement {
     
     // NEW: Cleanup kiosk mode monitoring
     this._cleanupKioskModeMonitoring();
+    
+    // Shared queue: remove storage event listener
+    if (this._storageEventHandler) {
+      window.removeEventListener('storage', this._storageEventHandler);
+      this._storageEventHandler = null;
+    }
+    if (this._queueSyncEventHandler) {
+      window.removeEventListener('ha-media-card-sync', this._queueSyncEventHandler);
+      this._queueSyncEventHandler = null;
+    }
     
     // V5.6: Cleanup viewport height observer
     this._cleanupDynamicViewportHeight();
@@ -1096,8 +1120,24 @@ export class MediaCard extends LitElement {
       this._log('Provider initialized:', success);
       
       if (success) {
-        // V5 FIX: If we reconnected with history, restore current media from history
-        if (this.history.length > 0 && this.historyPosition >= 0) {
+        // Shared queue takes priority over local history when configured — it holds the
+        // freshest cross-card state (what the other card was showing when this view was hidden).
+        const restoredFromShared = this._tryRestoreFromSharedQueue();
+
+        if (restoredFromShared) {
+          // Queue and index already set — jump directly to the saved item
+          const item = this.navigationQueue[this.navigationIndex];
+          if (item) {
+            this.currentMedia = item;
+            this._pendingNavigationIndex = this.navigationIndex;
+            this._pendingMediaPath = item.media_content_id;
+            this._pendingMetadata = null;
+            await this._resolveMediaUrl();
+          } else {
+            await this._loadNext();
+          }
+        } else if (this.history.length > 0 && this.historyPosition >= 0) {
+          // V5 FIX: If we reconnected with history, restore current media from history
           this._log('🔄 Reconnected with history - loading media at position', this.historyPosition);
           const historyItem = this.history[this.historyPosition];
           if (historyItem) {
@@ -1109,10 +1149,8 @@ export class MediaCard extends LitElement {
           }
         } else {
           this._log('Loading first media');
-          
           // V5.3: Smart pre-load - only for small collections
           await this._smartPreloadNavigationQueue();
-          
           await this._loadNext();
         }
         
@@ -3355,6 +3393,9 @@ export class MediaCard extends LitElement {
       this._pendingMediaPath = null;
     }
     
+    // Shared queue: broadcast navigation to other cards with same shared_queue_id
+    this._writeSharedQueueState();
+    
     this.requestUpdate();
   }
 
@@ -3778,6 +3819,135 @@ export class MediaCard extends LitElement {
     }
   }
 
+  // Shared Queue: write current queue state to localStorage and broadcast to same-window instances
+  _writeSharedQueueState() {
+    const id = this.config?.shared_queue_id;
+    if (!id || !this.navigationQueue?.length) return;
+    try {
+      const data = {
+        queue: this.navigationQueue.map(item => item.media_content_id),
+        currentIndex: this.navigationIndex,
+        updatedAt: Date.now(),
+        sourceCardId: this._cardId  // so listeners can ignore their own writes
+      };
+      localStorage.setItem(`ha-media-card:${id}`, JSON.stringify(data));
+      // Also broadcast within same window (storage event doesn't fire for same-window writes)
+      window.dispatchEvent(new CustomEvent('ha-media-card-sync', { detail: { sharedQueueId: id, ...data } }));
+    } catch (_e) {
+      // localStorage may be unavailable in some environments
+    }
+  }
+
+  // Shared Queue: called on reconnect (provider already exists) to sync queue state
+  // from localStorage so this card picks up where the other card left off
+  _syncFromSharedQueueOnReconnect() {
+    const id = this.config?.shared_queue_id;
+    if (!id) return;
+    try {
+      const raw = localStorage.getItem(`ha-media-card:${id}`);
+      if (!raw) return;
+      const data = JSON.parse(raw);
+      if (!Array.isArray(data.queue) || !data.queue.length) return;
+      const newIndex = Math.min(
+        typeof data.currentIndex === 'number' ? data.currentIndex : 0,
+        data.queue.length - 1
+      );
+      const newPath = data.queue[newIndex];
+      // Always restore the full queue so back-navigation history is preserved
+      this.navigationQueue = data.queue.map(mediaId => ({
+        media_content_id: mediaId,
+        media_content_type: MediaUtils.detectFileType(mediaId) || 'image',
+        title: mediaId.split('/').pop() || mediaId,
+        metadata: null
+      }));
+      this.navigationIndex = newIndex;
+      this._log(`🔗 Shared queue synced on reconnect: ${this.navigationQueue.length} items, index ${newIndex}`);
+      // Navigate to the current image if it differs from what we were last showing
+      if (newPath !== this._currentMediaPath) {
+        const item = this.navigationQueue[newIndex];
+        this.currentMedia = item;
+        this._pendingNavigationIndex = newIndex;
+        this._pendingMediaPath = newPath;
+        this._pendingMetadata = null;
+        this._resolveMediaUrl();
+        this.requestUpdate();
+      }
+    } catch (_e) {}
+  }
+
+  // Shared Queue: restore queue from localStorage on load
+  // Returns true if queue was restored (caller should skip normal provider init)
+  _tryRestoreFromSharedQueue() {
+    const id = this.config?.shared_queue_id;
+    if (!id) return false;
+    try {
+      const raw = localStorage.getItem(`ha-media-card:${id}`);
+      if (!raw) return false;
+      const data = JSON.parse(raw);
+      if (!Array.isArray(data.queue) || !data.queue.length) return false;
+      this.navigationQueue = data.queue.map(mediaId => ({
+        media_content_id: mediaId,
+        media_content_type: MediaUtils.detectFileType(mediaId) || 'image',
+        title: mediaId.split('/').pop() || mediaId,
+        metadata: null
+      }));
+      this.navigationIndex = Math.min(
+        typeof data.currentIndex === 'number' ? data.currentIndex : 0,
+        this.navigationQueue.length - 1
+      );
+      this._log(`🔗 Shared queue restored: ${this.navigationQueue.length} items, index ${this.navigationIndex}`);
+      return true;
+    } catch (_e) {
+      return false;
+    }
+  }
+
+  // Shared Queue: handle storage events from OTHER browser tabs/windows
+  _onStorageEvent(event) {
+    const id = this.config?.shared_queue_id;
+    if (!id || event.key !== `ha-media-card:${id}` || !event.newValue) return;
+    try {
+      const data = JSON.parse(event.newValue);
+      this._applySharedQueueUpdate(data);
+    } catch (_e) {
+      // ignore malformed data
+    }
+  }
+
+  // Shared Queue: handle CustomEvents from other card instances in the same window
+  _onQueueSyncEvent(event) {
+    const id = this.config?.shared_queue_id;
+    if (!id || event.detail?.sharedQueueId !== id) return;
+    if (event.detail?.sourceCardId === this._cardId) return; // ignore own writes
+    this._applySharedQueueUpdate(event.detail);
+  }
+
+  // Shared Queue: shared logic for applying an incoming queue update
+  _applySharedQueueUpdate(data) {
+    if (!Array.isArray(data.queue) || !data.queue.length) return;
+    const newIndex = Math.min(
+      typeof data.currentIndex === 'number' ? data.currentIndex : 0,
+      data.queue.length - 1
+    );
+    const newPath = data.queue[newIndex];
+    if (newPath === this._currentMediaPath) return; // already showing this
+    this._log(`🔗 Shared queue sync: navigating to index ${newIndex}`);
+    this.navigationQueue = data.queue.map(mediaId => ({
+      media_content_id: mediaId,
+      media_content_type: MediaUtils.detectFileType(mediaId) || 'image',
+      title: mediaId.split('/').pop() || mediaId,
+      metadata: null
+    }));
+    this.navigationIndex = newIndex;
+    const item = this.navigationQueue[newIndex];
+    this.currentMedia = item;
+    this._pendingNavigationIndex = newIndex;
+    this._pendingMediaPath = newPath;
+    this._pendingMetadata = null;
+    this._resolveMediaUrl();
+    this.requestUpdate();
+  }
+
   // V4: Keyboard navigation handler
   _handleKeyDown(e) {
     // Handle keyboard navigation
@@ -3995,6 +4165,9 @@ export class MediaCard extends LitElement {
       this._pendingNavigationIndex = null;
       this._log('✅ Applied pending navigation index on image load');
     }
+    
+    // Shared queue: broadcast navigation to other cards with same shared_queue_id
+    this._writeSharedQueueState();
     
     // Trigger re-render to show updated metadata/counters
     this.requestUpdate();
@@ -8741,8 +8914,8 @@ export class MediaCard extends LitElement {
     }
 
     .action-btn {
-      background: rgba(var(--rgb-card-background-color, 33, 33, 33), 0.8);
-      border: 1px solid rgba(var(--rgb-primary-text-color, 255, 255, 255), 0.2);
+      background: rgba(0, 0, 0, 0.55);
+      border: 1px solid rgba(255, 255, 255, 0.3);
       border-radius: 50%;
       width: 40px;
       height: 40px;
@@ -8751,70 +8924,86 @@ export class MediaCard extends LitElement {
       justify-content: center;
       cursor: pointer;
       transition: all 0.2s ease;
-      color: var(--primary-text-color);
+      color: #ffffff;
       backdrop-filter: blur(10px);
     }
 
     .action-btn:hover {
-      background: rgba(var(--rgb-card-background-color, 33, 33, 33), 0.95);
+      background: rgba(0, 0, 0, 0.75);
       transform: scale(1.15);
-      border-color: rgba(var(--rgb-primary-text-color, 255, 255, 255), 0.4);
+      border-color: rgba(255, 255, 255, 0.5);
     }
 
     .action-btn ha-icon {
       --mdc-icon-size: 24px;
+      color: #ffffff;
     }
 
     /* V4: Highlight pause button when paused */
     .pause-btn.paused {
-      color: var(--primary-color, #03a9f4);
-      background: rgba(3, 169, 244, 0.15);
+      background: rgba(3, 169, 244, 0.3);
     }
 
     .pause-btn.paused:hover {
-      color: var(--primary-color, #03a9f4);
-      background: rgba(3, 169, 244, 0.25);
+      background: rgba(3, 169, 244, 0.45);
+    }
+
+    .pause-btn.paused ha-icon {
+      color: #03a9f4;
     }
 
     /* V5.6.12: Mute button - highlight when muted */
     .mute-btn.muted {
-      color: var(--warning-color, #ff9800);
-      background: rgba(255, 152, 0, 0.15);
+      background: rgba(255, 152, 0, 0.3);
     }
 
     .mute-btn.muted:hover {
-      color: var(--warning-color, #ff9800);
-      background: rgba(255, 152, 0, 0.25);
+      background: rgba(255, 152, 0, 0.45);
+    }
+
+    .mute-btn.muted ha-icon {
+      color: #ff9800;
     }
 
     /* Debug button active state - warning color when enabled */
     .debug-btn.active {
-      color: var(--warning-color, #ff9800);
-      background: rgba(255, 152, 0, 0.15);
+      background: rgba(255, 152, 0, 0.3);
     }
 
     .debug-btn.active:hover {
-      color: var(--warning-color, #ff9800);
-      background: rgba(255, 152, 0, 0.25);
+      background: rgba(255, 152, 0, 0.45);
+    }
+
+    .debug-btn.active ha-icon {
+      color: #ff9800;
     }
 
     .favorite-btn.favorited {
-      color: var(--error-color, #ff5252);
-    }
-
-    .favorite-btn.favorited:hover {
-      color: var(--error-color, #ff5252);
       background: rgba(255, 82, 82, 0.1);
     }
 
+    .favorite-btn.favorited:hover {
+      background: rgba(255, 82, 82, 0.25);
+    }
+
+    .favorite-btn.favorited ha-icon {
+      color: #ff5252;
+    }
+
     .edit-btn:hover {
-      color: var(--warning-color, #ff9800);
       transform: scale(1.15);
     }
 
+    .edit-btn:hover ha-icon {
+      color: #ff9800;
+    }
+
     .delete-btn:hover {
-      color: var(--error-color, #ff5252);
       transform: scale(1.15);
+    }
+
+    .delete-btn:hover ha-icon {
+      color: #ff5252;
     }
 
     /* V4: Delete/Edit Confirmation Dialog */
@@ -9271,33 +9460,39 @@ export class MediaCard extends LitElement {
     }
 
     .info-btn.active {
-      color: var(--primary-color, #03a9f4);
-      background: rgba(3, 169, 244, 0.15);
+      background: rgba(3, 169, 244, 0.3);
     }
 
     .info-btn.active:hover {
-      color: var(--primary-color, #03a9f4);
-      background: rgba(3, 169, 244, 0.25);
+      background: rgba(3, 169, 244, 0.45);
+    }
+
+    .info-btn.active ha-icon {
+      color: #03a9f4;
     }
     
     .burst-btn.active {
-      color: var(--primary-color, #03a9f4);
-      background: rgba(3, 169, 244, 0.15);
+      background: rgba(3, 169, 244, 0.3);
     }
 
     .burst-btn.active:hover {
-      color: var(--primary-color, #03a9f4);
-      background: rgba(3, 169, 244, 0.25);
+      background: rgba(3, 169, 244, 0.45);
+    }
+
+    .burst-btn.active ha-icon {
+      color: #03a9f4;
     }
     
     .queue-btn.active {
-      color: var(--primary-color, #03a9f4);
-      background: rgba(3, 169, 244, 0.15);
+      background: rgba(3, 169, 244, 0.3);
     }
 
     .queue-btn.active:hover {
-      color: var(--primary-color, #03a9f4);
-      background: rgba(3, 169, 244, 0.25);
+      background: rgba(3, 169, 244, 0.45);
+    }
+
+    .queue-btn.active ha-icon {
+      color: #03a9f4;
     }
     
     .placeholder {

--- a/src/ui/media-card.js
+++ b/src/ui/media-card.js
@@ -4052,13 +4052,17 @@ export class MediaCard extends LitElement {
     this._storageEventHandler = this._onStorageEvent.bind(this);
     window.addEventListener('storage', this._storageEventHandler);
 
-    // Cross-device: subscribe to HA bus event fired by media_index.update_sync_state
+    // Cross-device: subscribe to HA bus event fired by media_index.update_sync_state.
+    // We use a custom WebSocket command (media_index/subscribe_sync) registered by the
+    // integration rather than the generic subscribe_events command, because subscribe_events
+    // requires admin for custom integration events — non-admin dashboard users would be
+    // refused. The custom command has its own handler that allows any authenticated user.
     if (this._hasCrossDeviceSync()) {
-      this._haSyncUnsubscribe = this.hass.connection.subscribeEvents(
-        (event) => this._onHaSyncEvent(event),
-        'media_index.sync_updated'
+      this._haSyncUnsubscribe = this.hass.connection.subscribeMessage(
+        (msg) => this._onHaSyncEvent({ data: msg }),
+        { type: 'media_index/subscribe_sync', sync_group: id }
       ).catch(e => {
-        this._log('⚠️ Failed to subscribe to media_index.sync_updated:', e);
+        this._log('⚠️ Failed to subscribe to media_index sync events:', e);
         this._haSyncUnsubscribe = null;
       });
     }

--- a/src/ui/media-card.js
+++ b/src/ui/media-card.js
@@ -1385,8 +1385,10 @@ export class MediaCard extends LitElement {
 
       // Leader election: if the user tapped/swiped on this card, it becomes the
       // new timer driver for the sync group, displacing any existing leader.
-      // Exception: locally paused (short press) — navigate silently without affecting group.
-      if (this._isManualNavigation && this.config?.shared_queue_id && !this._isLocallyPaused()) {
+      // This applies even when locally paused — an explicit button press means the
+      // user wants to control THIS card and it should fetch from its own provider,
+      // not wait for a cross-device broadcast.
+      if (this._isManualNavigation && this.config?.shared_queue_id) {
         this._forceClaimLeadership();
       }
 
@@ -1675,8 +1677,9 @@ export class MediaCard extends LitElement {
 
       // Leader election: if the user tapped/swiped on this card, it becomes the
       // new timer driver for the sync group, displacing any existing leader.
-      // Exception: locally paused (short press) — navigate silently without affecting group.
-      if (this._isManualNavigation && this.config?.shared_queue_id && !this._isLocallyPaused()) {
+      // This applies even when locally paused — an explicit button press means the
+      // user wants to control THIS card.
+      if (this._isManualNavigation && this.config?.shared_queue_id) {
         this._forceClaimLeadership();
       }
 

--- a/src/ui/media-card.js
+++ b/src/ui/media-card.js
@@ -1439,6 +1439,18 @@ export class MediaCard extends LitElement {
           this._pendingNavigationIndex = 0;
         } else {
           this._log('Navigation queue exhausted, loading from provider');
+          // Cross-device reconnect grace: when restoring at the last queue slot the
+          // driving device may be about to broadcast its next item.  Defer our own
+          // provider fetch so we follow the driver rather than racing it with a
+          // different item that would briefly flash on-screen before the sync corrects.
+          if (this._crossDeviceProviderFetchUntil && Date.now() < this._crossDeviceProviderFetchUntil) {
+            const remaining = this._crossDeviceProviderFetchUntil - Date.now();
+            this._log(`⏳ Cross-device grace: deferring provider fetch ${remaining}ms`);
+            // Retry when the window expires; a sync event clears the flag early.
+            setTimeout(() => { if (!this._isLocallyPaused()) this._loadNext(); }, remaining + 50);
+            return;
+          }
+          this._crossDeviceProviderFetchUntil = 0;
           // Capture generation before any awaits so we can detect if a sync event
           // arrived from another card while we were waiting for the provider.
           const _syncGenBefore = this._syncNavGeneration || 0;
@@ -4102,6 +4114,15 @@ export class MediaCard extends LitElement {
       this.navigationQueue.length - 1
     );
     this._log(`🔗 Shared queue restored: ${this.navigationQueue.length} items, index ${this.navigationIndex}`);
+    // Cross-device reconnect grace period: when we restore at the last (or only) slot
+    // the driver may be about to extend the queue and broadcast the next item.  Enter a
+    // short deferral window so the HA sync event arrives before we independently fetch a
+    // (potentially different) item from our own provider.  The window is cleared as soon
+    // as a sync event is received (in _applySharedQueueUpdate).
+    if (this._hasCrossDeviceSync() && this.navigationIndex >= this.navigationQueue.length - 1) {
+      this._crossDeviceProviderFetchUntil = Date.now() + 3000;
+      this._log('⏳ Cross-device grace period started (3s) — restored at end of shared queue');
+    }
     return true;
   }
 
@@ -4213,6 +4234,9 @@ export class MediaCard extends LitElement {
     // Also clear the cross-device follower deferral — the user is actively driving
     // from this device so it should immediately write to the shared DB state.
     this._crossDeviceFollowerUntil = 0;
+    // And clear the reconnect grace — user took control so local provider fetches
+    // are welcome immediately.
+    this._crossDeviceProviderFetchUntil = 0;
     this._log(`👑 Force-claimed sync leadership for group '${id}' (displaced: ${prev})`);
   }
 
@@ -4309,6 +4333,10 @@ export class MediaCard extends LitElement {
       return;
     }
     if (eventTs) this._lastAppliedSyncAt = eventTs;
+
+    // Clear reconnect grace period — the driver has broadcast its next item so
+    // we no longer need to defer provider fetches.
+    this._crossDeviceProviderFetchUntil = 0;
 
     const newIndex = Math.min(
       typeof data.currentIndex === 'number' ? data.currentIndex : 0,

--- a/src/ui/media-card.js
+++ b/src/ui/media-card.js
@@ -1389,7 +1389,7 @@ export class MediaCard extends LitElement {
       // user wants to control THIS card and it should fetch from its own provider,
       // not wait for a cross-device broadcast.
       if (this._isManualNavigation && this.config?.shared_queue_id) {
-        this._forceClaimLeadership();
+        this._claimDriverRole();
       }
 
     // V5.5: Panel Navigation Override (burst/related/on_this_day use _panelQueue)
@@ -1688,7 +1688,7 @@ export class MediaCard extends LitElement {
       // This applies even when locally paused — an explicit button press means the
       // user wants to control THIS card.
       if (this._isManualNavigation && this.config?.shared_queue_id) {
-        this._forceClaimLeadership();
+        this._claimDriverRole();
       }
 
       // V5.5: Panel Navigation Override (burst/related/on_this_day use _panelQueue)
@@ -4257,37 +4257,54 @@ export class MediaCard extends LitElement {
    * Used when the user manually navigates on a follower card — the active
    * device should become the driver to avoid the old leader overriding it.
    */
-  _forceClaimLeadership() {
+  /**
+   * Called on every manual navigation.  Handles TWO distinct but related concepts:
+   *
+   * Tier 1 — Same-window timer leadership (window._mediaCardLeaders):
+   *   Only one card per browser tab runs the auto-advance timer.  Manually
+   *   navigating on any card promotes it to timer leader, displacing any other
+   *   card that held the slot.  This prevents two timers competing on the same tab.
+   *
+   * Tier 2 — Cross-device HA write driver (_crossDeviceFollowerUntil):
+   *   Whichever browser/device the user is actively navigating on should write to
+   *   the HA media_index sync state.  Receiving a sync event from another device
+   *   sets _crossDeviceFollowerUntil = now+30s on this card, which blocks the HA
+   *   debounce write.  Manual navigation must clear that deferral unconditionally —
+   *   even if same-window leadership didn't change — so the HA write goes through
+   *   and the other browser receives the navigation update.
+   *
+   * Both tiers' state is reset BEFORE the early-return guard.  That guard only
+   * skips the window._mediaCardLeaders map update and log line; it must never
+   * skip the state resets.
+   */
+  _claimDriverRole() {
     const id = this.config?.shared_queue_id;
     if (!id) return;
     if (!window._mediaCardLeaders) window._mediaCardLeaders = new Map();
     const prev = window._mediaCardLeaders.get(id);
 
-    // Always clear ALL follower-mode state regardless of whether local window
-    // leadership changes.  A sync event from another device sets both
-    // _suppressSyncWriteUntil (echo guard) and _crossDeviceFollowerUntil (HA write
-    // gate) on this card.  If we only clear these when displacing a different local
-    // leader, manual navigation on the already-local-leader card still gets blocked
-    // from writing to HA — the other browser never receives the navigation.
-    this._suppressSyncWriteUntil = 0;
-    if (this._syncWriteTimer) {
-      clearTimeout(this._syncWriteTimer);
-      this._syncWriteTimer = null;
-    }
-    // Clear the cross-device follower deferral — the user is actively driving
-    // from this device so it should immediately write to the shared HA state.
+    // ── Tier 2: cross-device driver mode ──────────────────────────────────────
+    // Clear ALL cross-device follower/deferral state so the HA write goes through
+    // immediately, regardless of whether same-window leadership is changing.
     this._crossDeviceFollowerUntil = 0;
-    // And clear the reconnect grace — user took control so local provider fetches
-    // are welcome immediately.
     this._crossDeviceProviderFetchUntil = 0;
     if (this._crossDeviceGraceRetryTimer) {
       clearTimeout(this._crossDeviceGraceRetryTimer);
       this._crossDeviceGraceRetryTimer = null;
     }
+    // Clear the echo-suppression window.  A sync event from the other device may
+    // have set _suppressSyncWriteUntil just before the user navigated — without
+    // this reset the post-load _writeSharedQueueState() call would be dropped.
+    this._suppressSyncWriteUntil = 0;
+    if (this._syncWriteTimer) {
+      clearTimeout(this._syncWriteTimer);
+      this._syncWriteTimer = null;
+    }
 
-    if (prev === this._cardId) return; // Already local leader — state cleared above ✓
+    // ── Tier 1: same-window timer leadership ──────────────────────────────────
+    if (prev === this._cardId) return; // Already this tab's timer leader — Tier 2 reset above is sufficient ✓
     window._mediaCardLeaders.set(id, this._cardId);
-    this._log(`👑 Force-claimed sync leadership for group '${id}' (displaced: ${prev})`);
+    this._log(`👑 Claimed driver role for group '${id}' (displaced same-window leader: ${prev})`);
   }
 
   /**
@@ -4402,7 +4419,7 @@ export class MediaCard extends LitElement {
 
     // If the user pressed a button on THIS device while the sync arrived, let the
     // manual navigation win.  The manual _loadNext/_loadPrevious already called
-    // _forceClaimLeadership() which cleared _crossDeviceFollowerUntil; and
+    // _claimDriverRole() which cleared _crossDeviceFollowerUntil; and
     // _onHaSyncEvent already returned early so _crossDeviceFollowerUntil was not
     // re-set.  Nothing further to do here — the manual fetch will complete and
     // broadcast its own sync event to the driver.

--- a/src/ui/media-card.js
+++ b/src/ui/media-card.js
@@ -278,6 +278,22 @@ export class MediaCard extends LitElement {
     // Shared queue: register event listeners (cross-device HA events + same-device)
     this._subscribeToSyncEvents();
 
+    // Leader election: try to become the timer leader for this sync group.
+    // If the slot is empty this card claims it; otherwise it defers to the current leader.
+    this._tryClaimLeadership();
+
+    // Listen for the vacancy event fired when the leader disconnects, so a follower
+    // can step up and start its own timer.
+    this._leaderVacatedHandler = (e) => {
+      if (e.detail?.sharedQueueId !== this.config?.shared_queue_id) return;
+      const claimed = this._tryClaimLeadership();
+      if (claimed) {
+        this._log('👑 Stepping up as leader after vacancy — starting timer');
+        this._setupAutoRefresh();
+      }
+    };
+    window.addEventListener('ha-media-card-leader-vacated', this._leaderVacatedHandler);
+
     // Shared queue: if reconnecting (provider already exists), sync state from
     // media-index or localStorage to pick up where the other card left off
     if (this.provider && this.config?.shared_queue_id) {
@@ -295,7 +311,15 @@ export class MediaCard extends LitElement {
     
     // Shared queue: remove all event listeners and cancel pending debounced write
     this._unsubscribeFromSyncEvents();
-    
+
+    // Leader election: remove the vacancy listener and release leadership.
+    // _relinquishLeadership fires ha-media-card-leader-vacated so a follower steps up.
+    if (this._leaderVacatedHandler) {
+      window.removeEventListener('ha-media-card-leader-vacated', this._leaderVacatedHandler);
+      this._leaderVacatedHandler = null;
+    }
+    this._relinquishLeadership();
+
     // V5.6: Cleanup viewport height observer
     this._cleanupDynamicViewportHeight();
     
@@ -1359,6 +1383,12 @@ export class MediaCard extends LitElement {
       // The browser auto-pauses videos when they're removed from DOM
       this._navigatingAway = true;
 
+      // Leader election: if the user tapped/swiped on this card, it becomes the
+      // new timer driver for the sync group, displacing any existing leader.
+      if (this._isManualNavigation && this.config?.shared_queue_id) {
+        this._forceClaimLeadership();
+      }
+
     // V5.5: Panel Navigation Override (burst/related/on_this_day use _panelQueue)
     // Queue preview mode uses navigationQueue directly, so skip panel navigation
     if (this._panelOpen && this._panelQueue.length > 0 && this._panelMode !== 'queue') {
@@ -1609,6 +1639,12 @@ export class MediaCard extends LitElement {
     try {
       // V5.6: Set flag FIRST to ignore video pause events during navigation
       this._navigatingAway = true;
+
+      // Leader election: if the user tapped/swiped on this card, it becomes the
+      // new timer driver for the sync group, displacing any existing leader.
+      if (this._isManualNavigation && this.config?.shared_queue_id) {
+        this._forceClaimLeadership();
+      }
 
       // V5.5: Panel Navigation Override (burst/related/on_this_day use _panelQueue)
       // Queue preview mode uses navigationQueue directly, so skip panel navigation
@@ -1972,6 +2008,13 @@ export class MediaCard extends LitElement {
     
     if (this._backgroundPaused) {
       this._log('🔄 Auto-refresh setup skipped - background paused (not visible)');
+      return;
+    }
+
+    // Leader election: followers in a sync group must not run their own timer.
+    // The leader broadcasts navigation events; followers apply them via _applySharedQueueUpdate.
+    if (this.config?.shared_queue_id && !this._isSyncLeader()) {
+      this._log('👥 Sync follower — timer suppressed (leader handles advance)');
       return;
     }
 
@@ -4092,6 +4135,69 @@ export class MediaCard extends LitElement {
       clearTimeout(this._syncWriteTimer);
       this._syncWriteTimer = null;
     }
+  }
+
+  // Same-window leader election for shared_queue_id groups.
+  // Only the leader card runs the auto-advance timer; followers suppress theirs.
+  // This prevents two card instances (e.g. on different views of the same dashboard)
+  // from both firing timers and competing over which index to broadcast.
+
+  /** Returns true if this card is (or should act as) the timer leader. */
+  _isSyncLeader() {
+    const id = this.config?.shared_queue_id;
+    if (!id) return true; // No sync group — always act as leader
+    if (!window._mediaCardLeaders) return false;
+    return window._mediaCardLeaders.get(id) === this._cardId;
+  }
+
+  /**
+   * Attempt to register this card as the leader for its sync group.
+   * Succeeds only if the slot is empty.  Returns true if leadership was
+   * claimed (or was already held), false if another card holds the slot.
+   */
+  _tryClaimLeadership() {
+    const id = this.config?.shared_queue_id;
+    if (!id) return true;
+    if (!window._mediaCardLeaders) window._mediaCardLeaders = new Map();
+    const current = window._mediaCardLeaders.get(id);
+    if (!current) {
+      window._mediaCardLeaders.set(id, this._cardId);
+      this._log(`👑 Claimed sync leadership for group '${id}'`);
+      return true;
+    }
+    if (current === this._cardId) return true; // Already the leader
+    this._log(`👥 Sync follower for group '${id}' (leader: ${current})`);
+    return false;
+  }
+
+  /**
+   * Force-claim leadership, displacing any current leader.
+   * Used when the user manually navigates on a follower card — the active
+   * device should become the driver to avoid the old leader overriding it.
+   */
+  _forceClaimLeadership() {
+    const id = this.config?.shared_queue_id;
+    if (!id) return;
+    if (!window._mediaCardLeaders) window._mediaCardLeaders = new Map();
+    const prev = window._mediaCardLeaders.get(id);
+    if (prev === this._cardId) return; // Already leader
+    window._mediaCardLeaders.set(id, this._cardId);
+    this._log(`👑 Force-claimed sync leadership for group '${id}' (displaced: ${prev})`);
+  }
+
+  /**
+   * Release leadership and notify followers so one can step up.
+   * Called from disconnectedCallback.
+   */
+  _relinquishLeadership() {
+    const id = this.config?.shared_queue_id;
+    if (!id || !window._mediaCardLeaders) return;
+    if (window._mediaCardLeaders.get(id) !== this._cardId) return;
+    window._mediaCardLeaders.delete(id);
+    this._log(`👋 Relinquished sync leadership for group '${id}'`);
+    window.dispatchEvent(new CustomEvent('ha-media-card-leader-vacated', {
+      detail: { sharedQueueId: id }
+    }));
   }
 
   // HA websocket event from media_index (cross-device)

--- a/src/ui/media-card.js
+++ b/src/ui/media-card.js
@@ -185,6 +185,7 @@ export class MediaCard extends LitElement {
     this._previousNavigationIndex = null;  // Saved navigation index before navigation
     this._isLoadingNext = false;  // Re-entrance guard for _loadNext()
     this._isManualNavigation = false; // V5.6.7: Track if navigation is user-initiated vs timer-driven
+    this._manualNavLoading = false;    // True from navigation commit until _onMediaLoaded/_onVideoCanPlay fires
     
     // V5.6.0: Play randomized option for panels
     this._playRandomized = false;      // Toggle for randomizing panel playback order
@@ -1648,6 +1649,12 @@ export class MediaCard extends LitElement {
       this._fullMetadata = null;
       this._folderDisplayCache = null;
       
+      // Mark that a manual navigation is pending load — keeps _isManualNavigation
+      // semantics alive through the async image/video load phase so that any HA
+      // sync event arriving before _onMediaLoaded fires does not re-enter follower
+      // mode and suppress this card's own HA write.
+      if (this._isManualNavigation) this._manualNavLoading = true;
+
       await this._resolveMediaUrl();
       this.requestUpdate();
 
@@ -1663,10 +1670,11 @@ export class MediaCard extends LitElement {
     this._refreshMetadata().catch(err => this._log('⚠️ Metadata refresh failed:', err));
   } catch (error) {
     console.error('[MediaCard] Error loading next media:', error);
+    this._manualNavLoading = false; // Safety: clear on exception
   } finally {
     // V5.6.7: Always clear re-entrance guard
     this._isLoadingNext = false;
-    // V5.6.7: Always clear manual navigation flag after navigation completes
+    // Clear the in-flight flag. _manualNavLoading covers the remaining async load phase.
     this._isManualNavigation = false;
   }
 }
@@ -1749,7 +1757,11 @@ export class MediaCard extends LitElement {
     // V5: Clear cached full metadata when media changes
     this._fullMetadata = null;
     this._folderDisplayCache = null;
-    
+
+    // Mark that a manual navigation is pending load — keeps _isManualNavigation
+    // semantics alive through the async image/video load phase.
+    if (this._isManualNavigation) this._manualNavLoading = true;
+
     await this._resolveMediaUrl();
     this.requestUpdate();
     
@@ -1777,10 +1789,11 @@ export class MediaCard extends LitElement {
     this._refreshMetadata().catch(err => this._log('⚠️ Metadata refresh failed:', err));
     } catch (error) {
       console.error('[MediaCard] Error loading previous media:', error);
+      this._manualNavLoading = false; // Safety: clear on exception
     } finally {
       // V5.6.7: Always clear re-entrance guard
       this._isLoadingNext = false;
-      // V5.6.7: Always clear manual navigation flag after navigation completes
+      // Clear the in-flight flag. _manualNavLoading covers the remaining async load phase.
       this._isManualNavigation = false;
     }
   }
@@ -3467,6 +3480,8 @@ export class MediaCard extends LitElement {
   _onVideoCanPlay() {
     // V5.6.4: Timer uses simple counter, no timestamp needed
     this._log('🎬 Video ready - can play');
+    // Clear the manual-nav load-phase flag now that the media has committed to the DOM.
+    this._manualNavLoading = false;;
     
     // V5.8: Clear transient failure counter – video loaded successfully this time
     const itemId = this.currentMedia?.media_content_id;
@@ -4332,8 +4347,8 @@ export class MediaCard extends LitElement {
     // If the user is actively pressing a button on this card, let the manual
     // navigation complete first.  We do NOT extend the follower window because
     // this card is in the middle of taking over as driver.
-    if (this._isManualNavigation) {
-      this._log('🔗 Manual nav in progress — not entering follower mode for this sync event');
+    if (this._isManualNavigation || this._manualNavLoading) {
+      this._log('🔗 Manual nav in progress (or pending load) — not entering follower mode for this sync event');
       return;
     }
     // Mark this card as a cross-device follower for 30 s.  While in follower mode,
@@ -4431,8 +4446,8 @@ export class MediaCard extends LitElement {
     // _onHaSyncEvent already returned early so _crossDeviceFollowerUntil was not
     // re-set.  Nothing further to do here — the manual fetch will complete and
     // broadcast its own sync event to the driver.
-    if (this._isManualNavigation) {
-      this._log('\ud83d\uddb1\ufe0f Manual navigation in progress — ignoring incoming sync navigation');
+    if (this._isManualNavigation || this._manualNavLoading) {
+      this._log('\ud83d\uddb1\ufe0f Manual navigation in progress (or pending load) — ignoring incoming sync navigation');
       return;
     }
 
@@ -4611,10 +4626,14 @@ export class MediaCard extends LitElement {
   }
 
   _onMediaLoaded(e) {
+    // Clear the manual-nav load-phase flag now that the media has committed to the DOM.
+    // This must happen before any early returns below so the flag is never left set.
+    this._manualNavLoading = false;
+
     // Log media loaded for images (videos log in _onVideoLoadStart)
     if (!this._isVideoFile(this.mediaUrl)) {
       this._log('Media loaded successfully:', this.mediaUrl);
-      
+
       // V5.6.7: Clear navigation flag now that image is loaded
       // This prevents timer from firing prematurely during transitions
       this._navigatingAway = false;

--- a/src/ui/media-card.js
+++ b/src/ui/media-card.js
@@ -4263,21 +4263,19 @@ export class MediaCard extends LitElement {
     if (!window._mediaCardLeaders) window._mediaCardLeaders = new Map();
     const prev = window._mediaCardLeaders.get(id);
 
-    // Always clear the echo-suppression window regardless of whether leadership
-    // changes. A sync event from the follower may have set _suppressSyncWriteUntil
-    // on this card just before the user manually navigated – if we don't clear it
-    // here, the post-load _writeSharedQueueState() call is silently dropped even
-    // when this card is (and remains) the leader.
+    // Always clear ALL follower-mode state regardless of whether local window
+    // leadership changes.  A sync event from another device sets both
+    // _suppressSyncWriteUntil (echo guard) and _crossDeviceFollowerUntil (HA write
+    // gate) on this card.  If we only clear these when displacing a different local
+    // leader, manual navigation on the already-local-leader card still gets blocked
+    // from writing to HA — the other browser never receives the navigation.
     this._suppressSyncWriteUntil = 0;
     if (this._syncWriteTimer) {
       clearTimeout(this._syncWriteTimer);
       this._syncWriteTimer = null;
     }
-
-    if (prev === this._cardId) return; // Already leader — suppression cleared above ✓
-    window._mediaCardLeaders.set(id, this._cardId);
-    // Also clear the cross-device follower deferral — the user is actively driving
-    // from this device so it should immediately write to the shared DB state.
+    // Clear the cross-device follower deferral — the user is actively driving
+    // from this device so it should immediately write to the shared HA state.
     this._crossDeviceFollowerUntil = 0;
     // And clear the reconnect grace — user took control so local provider fetches
     // are welcome immediately.
@@ -4286,6 +4284,9 @@ export class MediaCard extends LitElement {
       clearTimeout(this._crossDeviceGraceRetryTimer);
       this._crossDeviceGraceRetryTimer = null;
     }
+
+    if (prev === this._cardId) return; // Already local leader — state cleared above ✓
+    window._mediaCardLeaders.set(id, this._cardId);
     this._log(`👑 Force-claimed sync leadership for group '${id}' (displaced: ${prev})`);
   }
 

--- a/src/ui/media-card.js
+++ b/src/ui/media-card.js
@@ -1441,34 +1441,36 @@ export class MediaCard extends LitElement {
           this._pendingNavigationIndex = 0;
         } else {
           this._log('Navigation queue exhausted, loading from provider');
-          // Cross-device follower mode: if this card received an HA sync event recently
-          // it means another device is the active driver.  Defer provider fetches and wait
-          // for the driver to broadcast the next item.  This cleanly prevents both devices
-          // independently fetching different items and causing flashes during normal running
-          // — not just at reconnect.  After _crossDeviceFollowerUntil expires (30s with no
-          // sync events) the card is free to fetch on its own (driver has gone away).
           const _nowMs = Date.now();
-          const _followerDefer = this._crossDeviceFollowerUntil && _nowMs < this._crossDeviceFollowerUntil;
-          const _reconnectDefer = this._crossDeviceProviderFetchUntil && _nowMs < this._crossDeviceProviderFetchUntil;
-          if (_followerDefer || _reconnectDefer) {
-            // Use the longer of the two windows as the remaining deferral time.
-            const remaining = Math.max(
-              _followerDefer ? this._crossDeviceFollowerUntil - _nowMs : 0,
-              _reconnectDefer ? this._crossDeviceProviderFetchUntil - _nowMs : 0
-            );
-            const reason = _followerDefer ? 'follower mode (driver active)' : 'reconnect grace';
-            this._log(`⏳ Cross-device defer (${reason}): waiting ${remaining}ms for driver broadcast`);
-            // Store the retry timer so it can be cancelled if a sync event arrives first.
+          const _followerDefer = !this._isManualNavigation &&
+              this._crossDeviceFollowerUntil && _nowMs < this._crossDeviceFollowerUntil;
+          const _reconnectDefer = !this._isManualNavigation &&
+              this._crossDeviceProviderFetchUntil && _nowMs < this._crossDeviceProviderFetchUntil;
+
+          if (_followerDefer) {
+            // Driver is active — it will broadcast when ready.  Return silently
+            // without queuing a retry; the retry was the source of endless noise.
+            // _applySharedQueueUpdate will navigate us when the broadcast arrives.
+            const waitSecs = Math.round((this._crossDeviceFollowerUntil - _nowMs) / 1000);
+            this._log(`⏳ Follower mode: waiting for driver broadcast (${waitSecs}s remaining)`);
+            return;
+          }
+
+          if (_reconnectDefer) {
+            // Reconnect grace: driver may still be active but HA event hasn't arrived yet.
+            // Set a one-shot retry; _applySharedQueueUpdate cancels it if broadcast arrives.
+            const remaining = this._crossDeviceProviderFetchUntil - _nowMs;
+            this._log(`⏳ Cross-device reconnect grace: deferring provider fetch ${remaining}ms`);
             if (this._crossDeviceGraceRetryTimer) clearTimeout(this._crossDeviceGraceRetryTimer);
             this._crossDeviceGraceRetryTimer = setTimeout(() => {
               this._crossDeviceGraceRetryTimer = null;
-              // Only retry if still at the end of the queue and no sync has advanced us.
               if (!this._isLocallyPaused() && this.navigationIndex >= this.navigationQueue.length - 1) {
                 this._loadNext();
               }
             }, remaining + 50);
             return;
           }
+
           this._crossDeviceProviderFetchUntil = 0;
           // Capture generation before any awaits so we can detect if a sync event
           // arrived from another card while we were waiting for the provider.
@@ -4291,6 +4293,13 @@ export class MediaCard extends LitElement {
     if (!id || data?.sync_group !== id) return;
     // Ignore events we ourselves wrote (media_index echoes back to all subscribers)
     if (data?.source_card_id === this._cardId) return;
+    // If the user is actively pressing a button on this card, let the manual
+    // navigation complete first.  We do NOT extend the follower window because
+    // this card is in the middle of taking over as driver.
+    if (this._isManualNavigation) {
+      this._log('🔗 Manual nav in progress — not entering follower mode for this sync event');
+      return;
+    }
     // Mark this card as a cross-device follower for 30 s.  While in follower mode,
     // auto-advance writes are suppressed so this card doesn't overwrite the driver's
     // DB state with its own independently-fetched queue items.  The window is generous
@@ -4370,6 +4379,17 @@ export class MediaCard extends LitElement {
     if (this._crossDeviceGraceRetryTimer) {
       clearTimeout(this._crossDeviceGraceRetryTimer);
       this._crossDeviceGraceRetryTimer = null;
+    }
+
+    // If the user pressed a button on THIS device while the sync arrived, let the
+    // manual navigation win.  The manual _loadNext/_loadPrevious already called
+    // _forceClaimLeadership() which cleared _crossDeviceFollowerUntil; and
+    // _onHaSyncEvent already returned early so _crossDeviceFollowerUntil was not
+    // re-set.  Nothing further to do here — the manual fetch will complete and
+    // broadcast its own sync event to the driver.
+    if (this._isManualNavigation) {
+      this._log('\ud83d\uddb1\ufe0f Manual navigation in progress — ignoring incoming sync navigation');
+      return;
     }
 
     const newIndex = Math.min(

--- a/src/ui/media-card.js
+++ b/src/ui/media-card.js
@@ -1385,7 +1385,8 @@ export class MediaCard extends LitElement {
 
       // Leader election: if the user tapped/swiped on this card, it becomes the
       // new timer driver for the sync group, displacing any existing leader.
-      if (this._isManualNavigation && this.config?.shared_queue_id) {
+      // Exception: locally paused (short press) — navigate silently without affecting group.
+      if (this._isManualNavigation && this.config?.shared_queue_id && !this._isLocallyPaused()) {
         this._forceClaimLeadership();
       }
 
@@ -1519,7 +1520,10 @@ export class MediaCard extends LitElement {
               }
               // We are the "first" card — broadcast our new item immediately so other
               // same-window cards adopt it synchronously before they exit their own awaits.
-              this._earlyBroadcastSyncState(nextIndex);
+              // Suppress if locally paused (short press) — don't affect the group.
+              if (!this._isLocallyPaused()) {
+                this._earlyBroadcastSyncState(nextIndex);
+              }
             }
           } else {
             // No more items available from provider, wrap to beginning with fresh query
@@ -1642,7 +1646,8 @@ export class MediaCard extends LitElement {
 
       // Leader election: if the user tapped/swiped on this card, it becomes the
       // new timer driver for the sync group, displacing any existing leader.
-      if (this._isManualNavigation && this.config?.shared_queue_id) {
+      // Exception: locally paused (short press) — navigate silently without affecting group.
+      if (this._isManualNavigation && this.config?.shared_queue_id && !this._isLocallyPaused()) {
         this._forceClaimLeadership();
       }
 
@@ -3447,8 +3452,10 @@ export class MediaCard extends LitElement {
       this._pendingMediaPath = null;
     }
     
-    // Shared queue: broadcast navigation to other cards with same shared_queue_id
-    this._writeSharedQueueState();
+    // Shared queue: broadcast navigation — suppress if locally paused (short press)
+    if (!this._isLocallyPaused()) {
+      this._writeSharedQueueState();
+    }
     
     this.requestUpdate();
   }
@@ -4139,6 +4146,16 @@ export class MediaCard extends LitElement {
 
   // Same-window leader election for shared_queue_id groups.
   // Only the leader card runs the auto-advance timer; followers suppress theirs.
+
+  /**
+   * Returns true when this card is paused locally (short press) as opposed to
+   * a group pause (long press).  Locally paused cards navigate silently and
+   * ignore incoming sync navigation events.
+   */
+  _isLocallyPaused() {
+    return this._isPaused && !this._groupPaused;
+  }
+
   // This prevents two card instances (e.g. on different views of the same dashboard)
   // from both firing timers and competing over which index to broadcast.
 
@@ -4290,14 +4307,20 @@ export class MediaCard extends LitElement {
     // continuously unpausing Device A.
     if (data.pauseIntent === true && typeof data.isPaused === 'boolean' && data.isPaused !== this._isPaused) {
       this._setPauseState(data.isPaused);
-      if (data.isPaused) { this._pauseTimer(); } else { this._resumeTimer(); }
+      if (data.isPaused) {
+        // Incoming group-pause: mark as group-paused so we know to broadcast on resume
+        this._groupPaused = true;
+        this._pauseTimer();
+      } else {
+        // Incoming group-resume: clear group-paused flag
+        this._groupPaused = false;
+        this._resumeTimer();
+      }
     }
 
-    // If this card is still paused after processing the intent, do not follow navigation
-    // from peers. The user intentionally paused this card; auto-advance from other running
-    // cards should not override that. A resume (pauseIntent=true, isPaused=false) will have
-    // already cleared _isPaused above, so the card resumes and still navigates.
-    if (this._isPaused) return;
+    // Locally paused (short press, not a group pause) — ignore sync navigation.
+    // Group-paused cards still follow navigation from the active card.
+    if (this._isPaused && !this._groupPaused) return;
 
     // Skip navigation if we are already showing this path OR already navigating to it.
     // The _pendingMediaPath check prevents duplicate navigation when the same update
@@ -4578,8 +4601,10 @@ export class MediaCard extends LitElement {
       this._log('✅ Applied pending navigation index on image load');
     }
     
-    // Shared queue: broadcast navigation to other cards with same shared_queue_id
-    this._writeSharedQueueState();
+    // Shared queue: broadcast navigation — suppress if locally paused (short press)
+    if (!this._isLocallyPaused()) {
+      this._writeSharedQueueState();
+    }
     
     // Trigger re-render to show updated metadata/counters
     this.requestUpdate();
@@ -5110,9 +5135,12 @@ export class MediaCard extends LitElement {
       <div class="action-buttons action-buttons-${position} ${this._showButtonsExplicitly ? 'show-buttons' : ''}">
         ${enablePause ? html`
           <button
-            class="action-btn pause-btn ${isPaused ? 'paused' : ''}"
+            class="action-btn pause-btn ${isPaused ? 'paused' : ''} ${isPaused && this._groupPaused ? 'group-paused' : ''}"
             @click=${this._handlePauseClick}
-            title="${isPaused ? 'Resume' : 'Pause'}">
+            @pointerdown=${this._handlePausePointerDown}
+            @pointerup=${this._handlePausePointerUp}
+            @pointercancel=${this._handlePausePointerUp}
+            title="${isPaused ? (this._groupPaused ? 'Resume Group' : 'Resume') : 'Pause'}">
             <ha-icon icon="${isPaused ? 'mdi:play' : 'mdi:pause'}"></ha-icon>
           </button>
         ` : ''}
@@ -6075,26 +6103,81 @@ export class MediaCard extends LitElement {
   }
 
   // V4: Handle pause button click
+  // Short press = local pause/resume only (no broadcast to sync group).
+  // Long press (via _handlePausePointerDown) = group pause/resume (broadcasts).
   _handlePauseClick(e) {
     e.stopPropagation();
-    
+
     // Restart timer on touch (gives user full time to choose next action)
     if (this._showButtonsExplicitly) {
       this._startActionButtonsHideTimer();
     }
-    
-    this._setPauseState(!this._isPaused);
-    
-    // Stop timer when pausing, restart when resuming
-    if (this._isPaused) {
+
+    // Long press already handled group pause — absorb the click that follows
+    if (this._pauseLongPressed) {
+      this._pauseLongPressed = false;
+      return;
+    }
+
+    const wasPaused = this._isPaused;
+    this._setPauseState(!wasPaused);
+
+    if (!wasPaused) {
+      // Short press PAUSE — local only, no broadcast
+      this._groupPaused = false;
       this._pauseTimer();
-      this._log('🎮 PAUSED slideshow - timer stopped');
+      this._log('🎮 PAUSED locally - timer stopped (short press, no broadcast)');
+    } else {
+      // RESUME
+      if (this._groupPaused) {
+        // Was group-paused: broadcast resume so all cards resume
+        this._groupPaused = false;
+        this._resumeTimer();
+        this._log('▶️ RESUMED slideshow — broadcasting group resume');
+        this._writeSharedQueueState(true);
+      } else {
+        // Was locally paused: resume locally, no broadcast
+        // Timer restart will naturally resync with the leader on next advance
+        this._resumeTimer();
+        this._log('▶️ RESUMED locally - resyncing to group state');
+      }
+    }
+  }
+
+  // Pointer handlers for the pause button to detect long press (group pause)
+  _handlePausePointerDown(e) {
+    e.stopPropagation(); // prevent card-level hold_action from firing
+    if (!this.config?.shared_queue_id) return; // group pause only relevant for sync groups
+    this._pauseLongPressed = false;
+    this._pauseHoldTimer = setTimeout(() => {
+      this._pauseHoldTimer = null;
+      this._pauseLongPressed = true;
+      this._handleGroupPause();
+    }, 600);
+  }
+
+  _handlePausePointerUp(e) {
+    e.stopPropagation();
+    if (this._pauseHoldTimer) {
+      clearTimeout(this._pauseHoldTimer);
+      this._pauseHoldTimer = null;
+    }
+  }
+
+  // Long press on pause button: toggle group pause state and broadcast to all cards
+  _handleGroupPause() {
+    const nowGroupPaused = !this._groupPaused;
+    this._groupPaused = nowGroupPaused;
+    this._setPauseState(nowGroupPaused);
+    if (nowGroupPaused) {
+      this._pauseTimer();
+      this._log('🔒 Group PAUSED — broadcasting to sync group');
     } else {
       this._resumeTimer();
-      this._log('▶️ RESUMED slideshow - timer restarted');
+      this._log('🔓 Group RESUMED — broadcasting to sync group');
     }
-    // Broadcast pause state to all synced cards
     this._writeSharedQueueState(true);
+    this.requestUpdate();
   }
   
   // Handle debug button click - toggle debug mode dynamically

--- a/src/ui/media-card.js
+++ b/src/ui/media-card.js
@@ -3909,6 +3909,15 @@ export class MediaCard extends LitElement {
     // that a pause arriving simultaneously with a navigation doesn't get swallowed.
     if (this._suppressSyncWrite && !pauseIntent) {
       this._suppressSyncWrite = false;
+      // Also cancel any pending debounced DB write — it was queued before the sync
+      // event arrived and would still fire (bypassing _suppressSyncWrite) if not
+      // explicitly cancelled here.  Without this, a stale echo of the sender's own
+      // trimmed queue reaches the sender with a clamped index, corrupting the driver's
+      // navigation queue when the driver has since advanced to a different item.
+      if (this._syncWriteTimer) {
+        clearTimeout(this._syncWriteTimer);
+        this._syncWriteTimer = null;
+      }
       return;
     }
     this._suppressSyncWrite = false;
@@ -4365,8 +4374,14 @@ export class MediaCard extends LitElement {
     // Use metadata from the sender if provided — avoids a round-trip fetch and
     // works even when this card has no media-index configured.
     this._pendingMetadata = data.currentMetadata || null;
-    // Suppress the outgoing write that would otherwise echo this event back
+    // Suppress the outgoing write that would otherwise echo this event back.
+    // Also cancel any in-flight debounced write immediately — defence-in-depth so
+    // the timer can't fire between now and when _writeSharedQueueState is next called.
     this._suppressSyncWrite = true;
+    if (this._syncWriteTimer) {
+      clearTimeout(this._syncWriteTimer);
+      this._syncWriteTimer = null;
+    }
     // Mark navigation in progress so the local slideshow timer doesn't fire a
     // competing _loadNext() while the sync-driven URL resolution is in flight.
     // _navigatingAway is cleared by _onMediaLoaded / _onVideoCanPlay as normal.

--- a/src/ui/media-card.js
+++ b/src/ui/media-card.js
@@ -4362,6 +4362,10 @@ export class MediaCard extends LitElement {
     if (!id || event.key !== `ha-media-card:${id}` || !event.newValue) return;
     try {
       const data = JSON.parse(event.newValue);
+      // Mirror the 30s follower deferral that _onHaSyncEvent sets for cross-device events.
+      // Without this, _suppressSyncWriteUntil expires after 1s and the follower card
+      // writes its (identical) state to HA — wasted service calls and log noise.
+      this._crossDeviceFollowerUntil = Date.now() + 30000;
       this._applySharedQueueUpdate(data);
     } catch (_e) {}
   }
@@ -4371,6 +4375,10 @@ export class MediaCard extends LitElement {
     const id = this.config?.shared_queue_id;
     if (!id || event.detail?.sharedQueueId !== id) return;
     if (event.detail?.sourceCardId === this._cardId) return; // ignore own writes
+    // Mirror the 30s follower deferral that _onHaSyncEvent sets for cross-device events.
+    // Without this, _suppressSyncWriteUntil expires after 1s and the follower card
+    // writes its (identical) state to HA — wasted service calls and log noise.
+    this._crossDeviceFollowerUntil = Date.now() + 30000;
     this._applySharedQueueUpdate(event.detail);
   }
 

--- a/src/ui/media-card.js
+++ b/src/ui/media-card.js
@@ -4274,6 +4274,15 @@ export class MediaCard extends LitElement {
       clearTimeout(this._crossDeviceGraceRetryTimer);
       this._crossDeviceGraceRetryTimer = null;
     }
+    // Clear the echo-suppression window set by _applySharedQueueUpdate.
+    // Without this, the first _writeSharedQueueState() call after taking control
+    // is silently dropped (and the pending debounce timer is also cancelled), so
+    // the other device never receives the HA sync event for the manual navigation.
+    this._suppressSyncWriteUntil = 0;
+    if (this._syncWriteTimer) {
+      clearTimeout(this._syncWriteTimer);
+      this._syncWriteTimer = null;
+    }
     this._log(`👑 Force-claimed sync leadership for group '${id}' (displaced: ${prev})`);
   }
 

--- a/src/ui/media-card.js
+++ b/src/ui/media-card.js
@@ -1439,13 +1439,23 @@ export class MediaCard extends LitElement {
           this._pendingNavigationIndex = 0;
         } else {
           this._log('Navigation queue exhausted, loading from provider');
-          // Cross-device reconnect grace: when restoring at the last queue slot the
-          // driving device may be about to broadcast its next item.  Defer our own
-          // provider fetch so we follow the driver rather than racing it with a
-          // different item.  The grace window equals the slide interval + 3s buffer.
-          if (this._crossDeviceProviderFetchUntil && Date.now() < this._crossDeviceProviderFetchUntil) {
-            const remaining = this._crossDeviceProviderFetchUntil - Date.now();
-            this._log(`⏳ Cross-device grace: deferring provider fetch ${remaining}ms`);
+          // Cross-device follower mode: if this card received an HA sync event recently
+          // it means another device is the active driver.  Defer provider fetches and wait
+          // for the driver to broadcast the next item.  This cleanly prevents both devices
+          // independently fetching different items and causing flashes during normal running
+          // — not just at reconnect.  After _crossDeviceFollowerUntil expires (30s with no
+          // sync events) the card is free to fetch on its own (driver has gone away).
+          const _nowMs = Date.now();
+          const _followerDefer = this._crossDeviceFollowerUntil && _nowMs < this._crossDeviceFollowerUntil;
+          const _reconnectDefer = this._crossDeviceProviderFetchUntil && _nowMs < this._crossDeviceProviderFetchUntil;
+          if (_followerDefer || _reconnectDefer) {
+            // Use the longer of the two windows as the remaining deferral time.
+            const remaining = Math.max(
+              _followerDefer ? this._crossDeviceFollowerUntil - _nowMs : 0,
+              _reconnectDefer ? this._crossDeviceProviderFetchUntil - _nowMs : 0
+            );
+            const reason = _followerDefer ? 'follower mode (driver active)' : 'reconnect grace';
+            this._log(`⏳ Cross-device defer (${reason}): waiting ${remaining}ms for driver broadcast`);
             // Store the retry timer so it can be cancelled if a sync event arrives first.
             if (this._crossDeviceGraceRetryTimer) clearTimeout(this._crossDeviceGraceRetryTimer);
             this._crossDeviceGraceRetryTimer = setTimeout(() => {

--- a/src/ui/media-card.js
+++ b/src/ui/media-card.js
@@ -269,14 +269,8 @@ export class MediaCard extends LitElement {
       this._startClockTimer();
     }
     
-    // V5: Restart auto-refresh if it was running before disconnect
-    // Only restart if we have a provider, currentMedia, and auto_advance is configured
-    if (this.provider && this.currentMedia && this.config.auto_advance_seconds > 0) {
-      this._log('🔄 Reconnected - restarting auto-refresh timer');
-      this._setupAutoRefresh();
-    }
-
-    // Shared queue: register event listeners (cross-device HA events + same-device)
+    // Shared queue: register event listeners and claim leadership BEFORE the reconnect
+    // auto-refresh below, so _setupAutoRefresh() correctly sees this card as leader.
     this._subscribeToSyncEvents();
 
     // Leader election: try to become the timer leader for this sync group.
@@ -284,16 +278,25 @@ export class MediaCard extends LitElement {
     this._tryClaimLeadership();
 
     // Listen for the vacancy event fired when the leader disconnects, so a follower
-    // can step up and start its own timer.
-    this._leaderVacatedHandler = (e) => {
-      if (e.detail?.sharedQueueId !== this.config?.shared_queue_id) return;
-      const claimed = this._tryClaimLeadership();
-      if (claimed) {
-        this._log('👑 Stepping up as leader after vacancy — starting timer');
-        this._setupAutoRefresh();
-      }
-    };
-    window.addEventListener('ha-media-card-leader-vacated', this._leaderVacatedHandler);
+    // can step up and start its own timer. Only registered when shared_queue_id is set.
+    if (this.config?.shared_queue_id) {
+      this._leaderVacatedHandler = (e) => {
+        if (e.detail?.sharedQueueId !== this.config?.shared_queue_id) return;
+        const claimed = this._tryClaimLeadership();
+        if (claimed) {
+          this._log('👑 Stepping up as leader after vacancy — starting timer');
+          this._setupAutoRefresh();
+        }
+      };
+      window.addEventListener('ha-media-card-leader-vacated', this._leaderVacatedHandler);
+    }
+
+    // V5: Restart auto-refresh if it was running before disconnect
+    // Only restart if we have a provider, currentMedia, and auto_advance is configured
+    if (this.provider && this.currentMedia && this.config.auto_advance_seconds > 0) {
+      this._log('🔄 Reconnected - restarting auto-refresh timer');
+      this._setupAutoRefresh();
+    }
 
     // Shared queue: if reconnecting (provider already exists), sync state from
     // media-index or localStorage to pick up where the other card left off
@@ -3481,7 +3484,7 @@ export class MediaCard extends LitElement {
     // V5.6.4: Timer uses simple counter, no timestamp needed
     this._log('🎬 Video ready - can play');
     // Clear the manual-nav load-phase flag now that the media has committed to the DOM.
-    this._manualNavLoading = false;;
+    this._manualNavLoading = false;
     
     // V5.8: Clear transient failure counter – video loaded successfully this time
     const itemId = this.currentMedia?.media_content_id;

--- a/src/ui/media-card.js
+++ b/src/ui/media-card.js
@@ -5094,7 +5094,9 @@ export class MediaCard extends LitElement {
     
     // Check individual button enable flags (default: true)
     const config = this.config.action_buttons || {};
-    const enablePause = config.enable_pause !== false;
+    // In single-media mode there is no auto-advance slideshow, so pause is irrelevant.
+    const isSingleMedia = this.config.media_source_type === 'single_media';
+    const enablePause = !isSingleMedia && config.enable_pause !== false;
     const enableFavorite = config.enable_favorite !== false;
     const enableDelete = config.enable_delete !== false;
     const enableEdit = config.enable_edit !== false;
@@ -5118,9 +5120,14 @@ export class MediaCard extends LitElement {
     // Show button if enabled and queue has items (or still loading)
     const showQueueButton = enableQueuePreview && this.navigationQueue && this.navigationQueue.length >= 1;
     
-    // V5.6.12: Mute button - show unless slideshow is configured for images only
+    // Mute button: hide when media is image-only.
+    // For single-media mode, use the actual file extension of the current item so the
+    // button is hidden when showing an image even if media_type was not explicitly set.
+    // For slideshow modes, fall back to the config media_type filter.
     const mediaType = this.config.media_type || 'all';
-    const showMuteButton = mediaType !== 'image';  // Show for 'all' or 'video'
+    const showMuteButton = isSingleMedia
+      ? MediaUtils.detectFileType(this._currentMediaPath || '') === 'video'
+      : mediaType !== 'image';
     
     // Don't render anything if all buttons are disabled
     const anyButtonEnabled = enablePause || showMuteButton || enableDebugButton || enableRefresh || enableFullscreen || 

--- a/src/ui/media-card.js
+++ b/src/ui/media-card.js
@@ -2718,6 +2718,12 @@ export class MediaCard extends LitElement {
     // If expectedNavigationIndex is provided and doesn't match current pending index, abort
     if (expectedNavigationIndex !== undefined && this._pendingNavigationIndex !== expectedNavigationIndex) {
       this._log(`⏭️ Skipping stale media resolution (expected: ${expectedNavigationIndex}, current: ${this._pendingNavigationIndex})`);
+      // Clear the navigation-in-progress flag when nothing else has claimed a pending
+      // path (i.e. no sync nav or newer _loadNext() is in flight). Without this,
+      // a stale return from a _loadNext() call that was superseded by a rapid sync
+      // burst can leave _navigatingAway=true permanently, causing the slideshow
+      // timer to log "Timer skipped" indefinitely.
+      if (!this._pendingMediaPath) this._navigatingAway = false;
       return;
     }
     
@@ -4232,6 +4238,10 @@ export class MediaCard extends LitElement {
     this._pendingMetadata = data.currentMetadata || null;
     // Suppress the outgoing write that would otherwise echo this event back
     this._suppressSyncWrite = true;
+    // Mark navigation in progress so the local slideshow timer doesn't fire a
+    // competing _loadNext() while the sync-driven URL resolution is in flight.
+    // _navigatingAway is cleared by _onMediaLoaded / _onVideoCanPlay as normal.
+    this._navigatingAway = true;
     this._resolveMediaUrl();
     this.requestUpdate();
     // For media-index cards: kick off a background fetch to get fresher/fuller

--- a/src/ui/media-card.js
+++ b/src/ui/media-card.js
@@ -4262,7 +4262,19 @@ export class MediaCard extends LitElement {
     if (!id) return;
     if (!window._mediaCardLeaders) window._mediaCardLeaders = new Map();
     const prev = window._mediaCardLeaders.get(id);
-    if (prev === this._cardId) return; // Already leader
+
+    // Always clear the echo-suppression window regardless of whether leadership
+    // changes. A sync event from the follower may have set _suppressSyncWriteUntil
+    // on this card just before the user manually navigated – if we don't clear it
+    // here, the post-load _writeSharedQueueState() call is silently dropped even
+    // when this card is (and remains) the leader.
+    this._suppressSyncWriteUntil = 0;
+    if (this._syncWriteTimer) {
+      clearTimeout(this._syncWriteTimer);
+      this._syncWriteTimer = null;
+    }
+
+    if (prev === this._cardId) return; // Already leader — suppression cleared above ✓
     window._mediaCardLeaders.set(id, this._cardId);
     // Also clear the cross-device follower deferral — the user is actively driving
     // from this device so it should immediately write to the shared DB state.
@@ -4273,15 +4285,6 @@ export class MediaCard extends LitElement {
     if (this._crossDeviceGraceRetryTimer) {
       clearTimeout(this._crossDeviceGraceRetryTimer);
       this._crossDeviceGraceRetryTimer = null;
-    }
-    // Clear the echo-suppression window set by _applySharedQueueUpdate.
-    // Without this, the first _writeSharedQueueState() call after taking control
-    // is silently dropped (and the pending debounce timer is also cancelled), so
-    // the other device never receives the HA sync event for the manual navigation.
-    this._suppressSyncWriteUntil = 0;
-    if (this._syncWriteTimer) {
-      clearTimeout(this._syncWriteTimer);
-      this._syncWriteTimer = null;
     }
     this._log(`👑 Force-claimed sync leadership for group '${id}' (displaced: ${prev})`);
   }

--- a/src/ui/media-card.js
+++ b/src/ui/media-card.js
@@ -1549,6 +1549,12 @@ export class MediaCard extends LitElement {
               // the provider (same-window CustomEvent fires mid-await), follow that card instead.
               if ((this._syncNavGeneration || 0) > _syncGenBefore) {
                 this._log('🔗 Another synced card broadcast first — following sync navigation, discarding locally-fetched item');
+                // IMPORTANT: also remove the item we just pushed from navigationQueue.
+                // _applySharedQueueUpdate replaced navigationQueue with the driver's queue,
+                // then our push added this item on top.  If we don't remove it, the next
+                // auto-advance will find the queue non-exhausted and navigate to this item
+                // directly — bypassing the follower defer check entirely.
+                this.navigationQueue.pop();
                 return;
               }
               // We are the "first" card — broadcast our new item immediately so other

--- a/src/ui/media-card.js
+++ b/src/ui/media-card.js
@@ -3907,20 +3907,19 @@ export class MediaCard extends LitElement {
     // Echo-prevention: skip the write that would bounce an incoming navigation sync
     // back to the sender. BUT always allow explicit pause/resume writes through so
     // that a pause arriving simultaneously with a navigation doesn't get swallowed.
-    if (this._suppressSyncWrite && !pauseIntent) {
-      this._suppressSyncWrite = false;
-      // Also cancel any pending debounced DB write — it was queued before the sync
-      // event arrived and would still fire (bypassing _suppressSyncWrite) if not
-      // explicitly cancelled here.  Without this, a stale echo of the sender's own
-      // trimmed queue reaches the sender with a clamped index, corrupting the driver's
-      // navigation queue when the driver has since advanced to a different item.
+    // Uses a timestamp window instead of a one-shot boolean so that double-load events
+    // (e.g. rapid-navigation clearing both layers fires two onload events for the same
+    // URL) don't consume the flag on the first load and then write on the second.
+    if (!pauseIntent && this._suppressSyncWriteUntil && Date.now() < this._suppressSyncWriteUntil) {
+      // Don't clear _suppressSyncWriteUntil — let it expire naturally so subsequent
+      // loads within the same sync event window are also suppressed.
       if (this._syncWriteTimer) {
         clearTimeout(this._syncWriteTimer);
         this._syncWriteTimer = null;
       }
       return;
     }
-    this._suppressSyncWrite = false;
+    this._suppressSyncWriteUntil = 0;
 
     // Always write localStorage for instant same-device sync
     try {
@@ -3943,7 +3942,10 @@ export class MediaCard extends LitElement {
     // Cross-device: debounced service call.
     // Accumulate pauseIntent across debounce resets so that a pause write that arrives
     // just before a navigation write doesn't silently lose the intent.
-    if (this._hasCrossDeviceSync()) {
+    // Cross-device write: only if we are acting as the driver (not a follower that
+    // recently received a sync event from another device).  Pause/resume intent always
+    // passes through so the user can group-pause from any device.
+    if (this._hasCrossDeviceSync() && (pauseIntent || Date.now() >= (this._crossDeviceFollowerUntil || 0))) {
       this._pendingSyncPauseIntent = (this._pendingSyncPauseIntent || false) || pauseIntent;
       if (this._syncWriteTimer) clearTimeout(this._syncWriteTimer);
       this._syncWriteTimer = setTimeout(() => {
@@ -4208,6 +4210,9 @@ export class MediaCard extends LitElement {
     const prev = window._mediaCardLeaders.get(id);
     if (prev === this._cardId) return; // Already leader
     window._mediaCardLeaders.set(id, this._cardId);
+    // Also clear the cross-device follower deferral — the user is actively driving
+    // from this device so it should immediately write to the shared DB state.
+    this._crossDeviceFollowerUntil = 0;
     this._log(`👑 Force-claimed sync leadership for group '${id}' (displaced: ${prev})`);
   }
 
@@ -4233,6 +4238,12 @@ export class MediaCard extends LitElement {
     if (!id || data?.sync_group !== id) return;
     // Ignore events we ourselves wrote (media_index echoes back to all subscribers)
     if (data?.source_card_id === this._cardId) return;
+    // Mark this card as a cross-device follower for 30 s.  While in follower mode,
+    // auto-advance writes are suppressed so this card doesn't overwrite the driver's
+    // DB state with its own independently-fetched queue items.  The window is generous
+    // enough to cover normal slideshow intervals; if the driver goes away, this card
+    // will naturally take over writing once the window expires.
+    this._crossDeviceFollowerUntil = Date.now() + 30000;
     let currentMetadata = null;
     if (data.current_metadata) {
       try { currentMetadata = JSON.parse(data.current_metadata); } catch (_e) {}
@@ -4375,9 +4386,10 @@ export class MediaCard extends LitElement {
     // works even when this card has no media-index configured.
     this._pendingMetadata = data.currentMetadata || null;
     // Suppress the outgoing write that would otherwise echo this event back.
-    // Also cancel any in-flight debounced write immediately — defence-in-depth so
-    // the timer can't fire between now and when _writeSharedQueueState is next called.
-    this._suppressSyncWrite = true;
+    // Use a 1-second window (timestamp) rather than a one-shot boolean so that the
+    // double-load race (rapid-navigation fires two onload events for the same URL)
+    // doesn't consume the flag prematurely on the first load.
+    this._suppressSyncWriteUntil = Date.now() + 1000;
     if (this._syncWriteTimer) {
       clearTimeout(this._syncWriteTimer);
       this._syncWriteTimer = null;

--- a/src/ui/media-card.js
+++ b/src/ui/media-card.js
@@ -1442,12 +1442,19 @@ export class MediaCard extends LitElement {
           // Cross-device reconnect grace: when restoring at the last queue slot the
           // driving device may be about to broadcast its next item.  Defer our own
           // provider fetch so we follow the driver rather than racing it with a
-          // different item that would briefly flash on-screen before the sync corrects.
+          // different item.  The grace window equals the slide interval + 3s buffer.
           if (this._crossDeviceProviderFetchUntil && Date.now() < this._crossDeviceProviderFetchUntil) {
             const remaining = this._crossDeviceProviderFetchUntil - Date.now();
             this._log(`⏳ Cross-device grace: deferring provider fetch ${remaining}ms`);
-            // Retry when the window expires; a sync event clears the flag early.
-            setTimeout(() => { if (!this._isLocallyPaused()) this._loadNext(); }, remaining + 50);
+            // Store the retry timer so it can be cancelled if a sync event arrives first.
+            if (this._crossDeviceGraceRetryTimer) clearTimeout(this._crossDeviceGraceRetryTimer);
+            this._crossDeviceGraceRetryTimer = setTimeout(() => {
+              this._crossDeviceGraceRetryTimer = null;
+              // Only retry if still at the end of the queue and no sync has advanced us.
+              if (!this._isLocallyPaused() && this.navigationIndex >= this.navigationQueue.length - 1) {
+                this._loadNext();
+              }
+            }, remaining + 50);
             return;
           }
           this._crossDeviceProviderFetchUntil = 0;
@@ -4116,12 +4123,17 @@ export class MediaCard extends LitElement {
     this._log(`🔗 Shared queue restored: ${this.navigationQueue.length} items, index ${this.navigationIndex}`);
     // Cross-device reconnect grace period: when we restore at the last (or only) slot
     // the driver may be about to extend the queue and broadcast the next item.  Enter a
-    // short deferral window so the HA sync event arrives before we independently fetch a
-    // (potentially different) item from our own provider.  The window is cleared as soon
-    // as a sync event is received (in _applySharedQueueUpdate).
+    // deferral window equal to the configured advance interval + 3s safety buffer so
+    // that the driver's HA sync event arrives BEFORE we independently fetch a (potentially
+    // different) item from our own provider.  The window is cancelled as soon as a
+    // sync event is received (in _applySharedQueueUpdate).
     if (this._hasCrossDeviceSync() && this.navigationIndex >= this.navigationQueue.length - 1) {
-      this._crossDeviceProviderFetchUntil = Date.now() + 3000;
-      this._log('⏳ Cross-device grace period started (3s) — restored at end of shared queue');
+      const advanceSecs = this.config?.auto_advance_seconds ||
+                          this.config?.auto_advance_interval ||
+                          this.config?.auto_advance_duration || 10;
+      const graceMs = advanceSecs * 1000 + 3000;
+      this._crossDeviceProviderFetchUntil = Date.now() + graceMs;
+      this._log(`⏳ Cross-device grace period started (${(graceMs/1000).toFixed(0)}s) — restored at end of shared queue`);
     }
     return true;
   }
@@ -4237,6 +4249,10 @@ export class MediaCard extends LitElement {
     // And clear the reconnect grace — user took control so local provider fetches
     // are welcome immediately.
     this._crossDeviceProviderFetchUntil = 0;
+    if (this._crossDeviceGraceRetryTimer) {
+      clearTimeout(this._crossDeviceGraceRetryTimer);
+      this._crossDeviceGraceRetryTimer = null;
+    }
     this._log(`👑 Force-claimed sync leadership for group '${id}' (displaced: ${prev})`);
   }
 
@@ -4335,8 +4351,13 @@ export class MediaCard extends LitElement {
     if (eventTs) this._lastAppliedSyncAt = eventTs;
 
     // Clear reconnect grace period — the driver has broadcast its next item so
-    // we no longer need to defer provider fetches.
+    // we no longer need to defer provider fetches.  Also cancel any pending retry
+    // setTimeout so it doesn't fire and independently advance after the sync.
     this._crossDeviceProviderFetchUntil = 0;
+    if (this._crossDeviceGraceRetryTimer) {
+      clearTimeout(this._crossDeviceGraceRetryTimer);
+      this._crossDeviceGraceRetryTimer = null;
+    }
 
     const newIndex = Math.min(
       typeof data.currentIndex === 'number' ? data.currentIndex : 0,


### PR DESCRIPTION
### Added
- **Cross-Device Slideshow Sync** (`shared_queue_id`): Multiple cards across any number of views, devices, and browsers share a single navigation queue and stay in lock-step. Set the same `shared_queue_id` on every participating card and they will always show the same image with a shared navigation history so back/forward work everywhere. Three complementary transports keep all cards in sync:
  - **Same-window**: `CustomEvent` bus for zero-latency sync between cards on the same browser tab. Exactly one card drives the slideshow timer — others suppress theirs and follow the leader. Manual navigation instantly promotes that card to leader; when a leader is destroyed the next card claims leadership automatically via a vacancy event
  - **Cross-view persistence**: `localStorage` so switching to a different dashboard view immediately shows the current image
  - **Cross-device**: When the `media_index` source is active, sync state is written through `media_index.update_sync_state` and delivered via the `media_index.sync_updated` HA event, keeping wall tablets, phones, and any other browser in sync in real time
  - **Pause sync**: Short-press pause stops only the local card; long-press (600 ms) broadcasts a group pause or resume to all peers. Locally paused cards silently ignore incoming navigation events. Only explicit user pause actions propagate — automatic advances never override a peer's pause state
  - Current image metadata (date, location, camera) is included in every sync payload so receiving cards display the correct information without extra service calls
  - Configure via the visual editor ("Shared Queue ID" in Image Options) or YAML: `shared_queue_id: "my_queue"`

### Fixed
- **Action buttons in single-media mode**: The action button strip is now context-aware when `media_source_type: single_media` is configured
  - **Pause button hidden**: There is no auto-advance slideshow timer in single-media mode, so the pause button is no longer shown
  - **Mute button follows actual file type**: The mute button now shows or hides based on the file extension of the currently displayed item rather than the configured `media_type` filter — so it correctly appears for videos and is hidden for images even when `media_type` is not explicitly set

- **Action button colors washed out on light and frosted-glass themes**: Button backgrounds were derived from `--rgb-card-background-color`, which resolves to near-white on many light themes, making icons invisible. Fixed by using hardcoded dark semi-transparent backgrounds (`rgba(0,0,0,0.55)`) and explicit white icon colors. Active-state colors (mute, pause, info, burst, queue, favorite) are now set directly on the `ha-icon` element so they work correctly on all themes.