### PR TITLE
Add iCloud Photos preset and Live Photo playback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Roku xcast Cast Support**: The cast button now supports direct Roku TV casting via the [xcast ECP protocol](https://channelstore.roku.com/details/687485) in addition to the existing `media_player.play_media` mirror
+  - Roku `media_player` entities are identified automatically by the presence of an `app_id` attribute and routed via `media_index.roku_ecp_cast` (server-side ECP call) instead of `media_player.play_media`
+  - Roku devices appear first in the cast picker with a green left-border accent
+  - **Requires**: [Media Index](https://github.com/markaggar/ha-media-index) v1.7.1+, Roku HA integration, and the [xcast](https://channelstore.roku.com/details/687485) channel installed on the Roku
+
+### Changed
+
+- **Cast picker replaced browser `prompt()` with a card-native frosted-glass dialog**: Clickable device list replaces the numbered text prompt; matches the card's existing design language (same frosted-glass style as the delete confirmation). Each item shows device name and current state. Tap outside the panel or Cancel to dismiss.
+
+- **Cast stop now clears the Roku display**: When a cast session is stopped (button tap or card disconnect), `media_index.stop_cast` (ECP `keypress/Home`) is called, returning the Roku to its home screen instead of leaving the last image frozen on the TV
+
+- **Cast stop fires on card disconnect**: Navigating away from a dashboard containing the card now automatically stops any active Roku cast session
+
+- **Improved first-cast reliability for cold-start xcast**: The current image is pushed immediately on cast activation (waking xcast if not running) and again after 2.5 s. If xcast was cold-starting, the retry arrives once it is fully launched; if it was already running, the first push shows the image instantly.
+
+---
+
 ## v5.10.0 - 2026-04-22
 
 ### Added
+- **Cast to TV** (`show_cast_button: true`): Cast button (opt-in) in the action toolbar lets users mirror the card's current media to any HA `media_player` entity (LG WebOS, Chromecast, etc.) in real time.
+  - Tap the cast icon to open a picker showing all `media_player` entities. Select one to start mirroring — every time the card advances, the same item is pushed to the TV via `media_player.play_media`.
+  - While a cast session is active the button shows `mdi:cast-connected` and a stop-cast tooltip. Tap again to stop.
+  - Uses the card's existing `shared_queue_id` if configured; otherwise generates a transient sync group for the session.
+  - Powered by new ha-media-index services: `mirror_to_cast`, `start_cast_slideshow`, `stop_cast_slideshow` (see ha-media-index CHANGELOG).
+  - Opt-in via config: `show_cast_button: true`
 - **Cross-Device Slideshow Sync** (`shared_queue_id`): Multiple cards across any number of views, devices, and browsers share a single navigation queue and stay in lock-step. Set the same `shared_queue_id` on every participating card and they will always show the same image with a shared navigation history so back/forward work everywhere. Three complementary transports keep all cards in sync:
   - **Same-window**: `CustomEvent` bus for zero-latency sync between cards on the same browser tab. Exactly one card drives the slideshow timer — others suppress theirs and follow the leader. Manual navigation instantly promotes that card to leader; when a leader is destroyed the next card claims leadership automatically via a vacancy event
   - **Cross-view persistence**: `localStorage` so switching to a different dashboard view immediately shows the current image

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+---
+
+## [v5.11.0] - 2026-05-14
+
 ### Added
 
 - **Roku xcast Cast Support**: The cast button now supports direct Roku TV casting via the [xcast ECP protocol](https://channelstore.roku.com/details/687485) in addition to the existing `media_player.play_media` mirror
   - Roku `media_player` entities are identified automatically by the presence of an `app_id` attribute and routed via `media_index.roku_ecp_cast` (server-side ECP call) instead of `media_player.play_media`
   - Roku devices appear first in the cast picker with a green left-border accent
-  - **Requires**: [Media Index](https://github.com/markaggar/ha-media-index) v1.7.1+, Roku HA integration, and the [xcast](https://channelstore.roku.com/details/687485) channel installed on the Roku
+  - **Requires**: [Media Index](https://github.com/markaggar/ha-media-index) v1.8.0+, Roku HA integration, and the [xcast](https://channelstore.roku.com/details/687485) channel installed on the Roku
+
+- **Swipe Gesture Navigation**: Swipe left to advance and swipe right to go back on touch screens
+  - Works on both images and video — the `touchstart` on the video element no longer blocks swipe detection in the parent container
+  - Minimum 50 px horizontal travel required; gesture is cancelled if vertical movement exceeds horizontal so intentional scroll is not intercepted
+
+- **Date Range Filters for Sequential Mode**: `get_ordered_files` (sequential/ordered provider) now accepts `filters.date_range.start` and `filters.date_range.end`
+  - Values can be `YYYY-MM-DD` strings or HA entity IDs (the card reads the entity state and strips any time component)
+  - Passed to the backend as `date_from` / `date_to` on every page fetch, including cursor-based continuation pages
 
 ### Changed
 
@@ -23,6 +35,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Cast stop fires on card disconnect**: Navigating away from a dashboard containing the card now automatically stops any active Roku cast session
 
 - **Improved first-cast reliability for cold-start xcast**: The current image is pushed immediately on cast activation (waking xcast if not running) and again after 2.5 s. If xcast was cold-starting, the retry arrives once it is fully launched; if it was already running, the first push shows the image instantly.
+
+- **Cast button help text clarifies Roku-only media_index dependency**: The visual editor now accurately states that Roku uses `media_index.roku_ecp_cast` (requires media_index), while other players (LG, Chromecast, etc.) use `media_player.play_media` directly and do not require media_index.
+
+### Fixed
+
+- **Touch interactions on video not working (swipe, hold, double-tap)**: All three gestures were broken when the user's finger landed on the `<video>` element
+  - Swipe: `touchstart` on the video called `stopPropagation()`, so the `.media-container` swipe handler never recorded a start position
+  - Hold (long-press): `pointerdown` on the video called `stopPropagation()`, so the hold timer in the parent container was never started
+  - Double-tap: the video's `click` handler called `stopPropagation()`, so a `dblclick` on the container never fired — fixed by binding `@dblclick` directly on the `<video>` element
+
+- **Sequential mode DESC order returning oldest files first**: The `get_ordered_files` sort expression incorrectly wrapped an already-integer `date_taken` Unix timestamp in SQLite's `unixepoch()`, which treats the integer as a Julian Day Number and produces large negative values — causing 2018 photos to rank above 2026 photos in descending order.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,14 @@ It is highly recommended you also install the [Media Index Integration](https://
 - 🎯 **Priority Folders**: Boost visibility of recent photos or favorites (3x, 2x multipliers)
 - ⏯️ **Smart Pause/Resume**: Slideshow automatically pauses when you pause a video, navigate away, or switch tabs. Resumes right where you left off when you return.
 
+### **📺 Cast to TV** (requires Media Index)
+- 📺 **Cast Button** (`show_cast_button: true`): Tap the cast icon to open a native picker showing all `media_player` entities. Every time the card advances, the same item is pushed to the TV in real time.
+- **Roku xcast**: Roku TV entities are automatically detected and cast via the [xcast ECP protocol](https://channelstore.roku.com/details/687485) for native image display without transcoding by the TV — no DLNA/DMR required.
+  - **Requirements for Roku**: Roku HA integration configured, [xcast channel](https://channelstore.roku.com/details/687485) installed on the Roku device, and Media Index v1.7.1+
+  - The xcast channel acts as a Digital Media Renderer (DMR) receiving content pushed from HA. It must be installed from the Roku Channel Store before first use. On a cold-start the card sends the image immediately to wake xcast, then retries 2.5 s later once it has fully launched.
+- **Generic media players** (LG WebOS, Chromecast, etc.): Cast via `media_player.play_media` — requires the player to support DMR/HTTP URLs.
+- **Stop cast**: Tap the cast button again or navigate away to stop. For Roku, this sends a `keypress/Home` ECP command so the TV returns to its home screen instead of showing a frozen image.
+
 ## Installation 
 
 ### Install via HACS

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 [![Buy Me A Coffee](https://img.shields.io/badge/Buy%20Me%20A%20Coffee-Support-orange?logo=buy-me-a-coffee)](https://buymeacoffee.com/markaggar)
 
 # HA Media Card 🎬
-A powerful custom Home Assistant Dashboard card that displays images and videos with **smart slideshow behavior**, **hierarchical folder scanning**, **rich metadata displays**, and **intelligent content prioritization**. Features include **multi-level folder management**, **precision navigation controls**, **video completion detection**, and a **built-in media browser** for easy file selection. Perfect for displaying family photos, security camera snapshots, or any media files from your Home Assistant media folders with performance optimization. 100% developed with VS Code using GitHub Copilot with Claude Sonnet 4.0/4.5.
+A powerful custom Home Assistant Dashboard card that displays images and videos with **smart slideshow behavior**, **hierarchical folder scanning**, **rich metadata displays**, **intelligent content prioritization** and **TV casting support**. Features include **multi-level folder management**, **precision navigation controls**, **video completion detection**, and a **built-in media browser** for easy file selection. Perfect for displaying family photos, security camera snapshots, or any media files from your Home Assistant media folders with performance optimization. 100% developed with VS Code using GitHub Copilot with Claude Sonnet 4.0/4.5.
 
-It is highly recommended you also install the [Media Index Integration](https://github.com/markaggar/ha-media-index) that is required for many of the cool features of Media Card - Reduced scanning overhead (Media Index does this periodically instead of Media Card everytime you load the card), EXIF metadata extraction, favoriting, editing and deleting photos and related photos support.
+It is highly recommended you also install the [Media Index Integration](https://github.com/markaggar/ha-media-index) that is required for many of the cool features of Media Card - Reduced scanning overhead (Media Index does this periodically instead of Media Card everytime you load the card), EXIF metadata extraction, Roku Casting, favoriting, editing and deleting photos and related photos support.
 
 <img width="691" height="925" alt="Media Card displaying a photo with metadata" src="docs/media-card.gif" />
 
@@ -43,6 +43,7 @@ It is highly recommended you also install the [Media Index Integration](https://
 - 🔗 **Cross-Device Shared Queue** (`shared_queue_id`): Keep multiple cards — on different views, tablets, phones, or any device — locked to the same image with shared history and pause state. Same-window sync is instant via browser events; cross-browser and cross-device sync uses Home Assistant events (requires Media Index).
 - 📋 **Queue Preview Panel**: View upcoming and previous items in your slideshow queue with thumbnail navigation
 - ⌨️ **Keyboard Shortcuts**: Arrow keys, space, and more
+- 📲 **Touch Screen Support**: Swipe left/right, pause etc.
 - 👆 **Interactive Actions**: Tap, hold, and double-tap customization with optional custom confirmation messages
 ### **Media Discovery Features** (requires Media Index)
 - 📸 **Burst Review**: Review rapid-fire photos taken at the same moment to select the best shot
@@ -55,8 +56,7 @@ It is highly recommended you also install the [Media Index Integration](https://
 - 🔍 **Media Index Integration**: Database-backed selection with enhanced metadata
 - 🌲 **Hierarchical Scanning**: Handle thousands of files across nested folders efficiently with near immediate display of images
 - 🎯 **Priority Folders**: Boost visibility of recent photos or favorites (3x, 2x multipliers)
-- ⏯️ **Smart Pause/Resume**: Slideshow automatically pauses when you pause a video, navigate away, or switch tabs. Resumes right where you left off when you return.
-
+- ⏯️ **Smart Pause/Resume**: Slideshow automatically pauses when you pause a video, navigate away, or switch tabs. Resumes right where you left off when you return
 ### **📺 Cast to TV** (requires Media Index)
 - 📺 **Cast Button** (`show_cast_button: true`): Tap the cast icon to open a native picker showing all `media_player` entities. Every time the card advances, the same item is pushed to the TV in real time.
 - **Roku xcast**: Roku TV entities are automatically detected and cast via the [xcast ECP protocol](https://channelstore.roku.com/details/687485) for native image display without transcoding by the TV — no DLNA/DMR required.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ It is highly recommended you also install the [Media Index Integration](https://
 - 📂 **Multiple Folder Modes**: Sequential or Random selection of media from folders with optional file system recursion
 - 🔄 **Auto-Advance/Refresh**: Configurable intervals for dynamic content
 - 🎥 **Video Controls**: Autoplay, loop, mute and limit video length
+- 🎞️ **Live Photo Playback**: Pair still images with iCloud-style companion videos and play them as still → motion → pause loops
+- ☁️ **iCloud Photos Preset**: Point the card at a server-side iCloud sync folder with photo, video, and Live Photo display defaults in one config area
 - 🖼️ **Aspect Ratio Control**: Optimize display for any layout (panel, card, fullscreen)
 - **✨ Image Zoom**: Click to zoom into any point of an image, click again to reset (configurable zoom level 1.5-5x)
 - **🎞️ Photo Transitions**: Configurable crossfade transitions between images (0-1000ms) for smooth slideshow experience

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ It is highly recommended you also install the [Media Index Integration](https://
 - 🎥 **Video Controls**: Autoplay, loop, mute and limit video length
 - 🎞️ **Live Photo Playback**: Pair still images with iCloud-style companion videos and play them as still → motion → pause loops
 - ☁️ **iCloud Photos Preset**: Point the card at a server-side iCloud sync folder with photo, video, and Live Photo display defaults in one config area
+- ☁️ **iCloud Sync Onboarding**: The card editor links to the AncilTech iCloud Photo Sync add-on and shows the media-source path to use after sync
 - 🖼️ **Aspect Ratio Control**: Optimize display for any layout (panel, card, fullscreen)
 - **✨ Image Zoom**: Click to zoom into any point of an image, click again to reset (configurable zoom level 1.5-5x)
 - **🎞️ Photo Transitions**: Configurable crossfade transitions between images (0-1000ms) for smooth slideshow experience

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -65,6 +65,9 @@ live_photo:
   still_duration: 1
   repeat_delay: 10
   hide_companion_videos: true
+heic:
+  enabled: true
+  quality: 0.92
 video_loop: false
 video_muted: true
 ```
@@ -116,6 +119,27 @@ Recommended add-on install path:
 3. Install `iCloud Photo Sync`, configure the album and `/media/icloud_photos` destination, then run the add-on's documented Apple initialise step from an HAOS shell.
 
 This downloader is installed through the Home Assistant Add-on Store repository flow, not HACS. HACS remains the normal path for installing the frontend card itself.
+
+### HEIC/HEIF Display Fallback
+
+Browsers do not consistently display Apple HEIC/HEIF files. The card can treat `.heic` and `.heif` files as images and convert them in the browser before rendering. This is intended as a fallback for synced iCloud photos that do not have a JPEG conversion available yet; server-side JPEG conversion is still faster for always-on dashboards.
+
+```yaml
+type: custom:media-card
+media_type: all
+heic:
+  enabled: true
+  library_url: https://cdn.jsdelivr.net/npm/heic2any@0.0.4/dist/heic2any.min.js
+  output_type: image/jpeg
+  quality: 0.92
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `heic.enabled` | boolean | `true` | Convert HEIC/HEIF images in the browser before display |
+| `heic.library_url` | string | `https://cdn.jsdelivr.net/npm/heic2any@0.0.4/dist/heic2any.min.js` | URL for the `heic2any` converter script; host a local copy if the dashboard must work offline |
+| `heic.output_type` | string | `image/jpeg` | Converted image MIME type |
+| `heic.quality` | number | `0.92` | JPEG output quality passed to the converter |
 
 ### Display Options
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -110,13 +110,14 @@ live_photo:
 | `icloud_photos.album` | string | `""` | Optional album folder below the sync root |
 | `icloud_photos.sync_backend` | string | `icloudpd` | Descriptive backend name for the server-side sync source |
 
-The card does not perform Apple authentication in the browser. Use a Home Assistant add-on or integration to sync iCloud Photos into `/media/icloud_photos`, then use this preset as the single card-level display configuration.
+The card does not perform Apple authentication in the browser. Use a Home Assistant add-on or integration to sync iCloud Photos into `/media/icloud_photos`, then use this preset as the single card-level display configuration. The card editor also shows an iCloud Photos Sync panel in folder mode with the recommended add-on link and media-source path.
 
 Recommended add-on install path:
 
 1. In Home Assistant, go to `Settings -> Add-ons -> Add-on Store`.
 2. Open the top-right menu, choose `Repositories`, and add `https://github.com/anciltech/ha-icloud-photo-sync`.
 3. Install `iCloud Photo Sync`, configure the album and `/media/icloud_photos` destination, then run the add-on's documented Apple initialise step from an HAOS shell.
+4. Use `media-source://media_source/local/icloud_photos` as the card folder path, or append the album folder created by the sync.
 
 This downloader is installed through the Home Assistant Add-on Store repository flow, not HACS. HACS remains the normal path for installing the frontend card itself.
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -52,6 +52,23 @@ media_type: all
 auto_advance_duration: 5
 ```
 
+**iCloud Photos with Live Photos**
+```yaml
+type: custom:media-card
+icloud_photos:
+  enabled: true
+  album: Favorites
+media_type: all
+auto_advance_seconds: 60
+live_photo:
+  enabled: true
+  still_duration: 1
+  pause_duration: 10
+  hide_companion_videos: true
+video_loop: false
+video_muted: true
+```
+
 ## Core Configuration
 
 ### Media Source Selection
@@ -65,6 +82,40 @@ auto_advance_duration: 5
 | `folder.path` | string | Required for folder | Path to folder (media-source:// URI) |
 | `folder.mode` | string | `random` | Display mode: `random`, `sequential` |
 | `folder.recursive` | boolean | `false` | Include subfolders in scan |
+
+### iCloud Photos Preset
+
+The card can own the display side of an iCloud Photos setup when a server-side sync backend is already writing files into Home Assistant media storage. The preset points the card at the synced folder, enables folder mode, allows photos and videos, and turns on Live Photo pairing.
+
+```yaml
+type: custom:media-card
+icloud_photos:
+  enabled: true
+  media_source_path: media-source://media_source/local/icloud_photos
+  album: Favorites
+media_type: all
+auto_advance_seconds: 60
+live_photo:
+  still_duration: 1
+  pause_duration: 10
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `icloud_photos.enabled` | boolean | `false` | Enable iCloud Photos display defaults |
+| `icloud_photos.media_source_path` | string | `media-source://media_source/local/icloud_photos` | Root folder populated by the sync backend |
+| `icloud_photos.album` | string | `""` | Optional album folder below the sync root |
+| `icloud_photos.sync_backend` | string | `icloudpd` | Descriptive backend name for the server-side sync source |
+
+The card does not perform Apple authentication in the browser. Use a Home Assistant add-on or integration to sync iCloud Photos into `/media/icloud_photos`, then use this preset as the single card-level display configuration.
+
+Recommended add-on install path:
+
+1. In Home Assistant, go to `Settings -> Add-ons -> Add-on Store`.
+2. Open the top-right menu, choose `Repositories`, and add `https://github.com/anciltech/ha-icloud-photo-sync`.
+3. Install `iCloud Photo Sync`, configure the album and `/media/icloud_photos` destination, then run the add-on's documented Apple initialise step from an HAOS shell.
+
+This downloader is installed through the Home Assistant Add-on Store repository flow, not HACS. HACS remains the normal path for installing the frontend card itself.
 
 ### Display Options
 
@@ -413,6 +464,36 @@ When `auto_refresh_seconds > 0` and a video finishes playing:
 - Slideshow automatically advances to next item
 - Respects manual pause - won't advance if user paused video
 - Works with all slideshow behaviors
+
+## Live Photo Options
+
+Live Photos downloaded from iCloud are usually represented as a still image plus a companion video file. When enabled, the card treats the still image as the slideshow item, resolves the matching companion video, shows the still for a short moment, plays the video once, returns to the still, waits, and repeats while that slideshow item remains active.
+
+```yaml
+live_photo:
+  enabled: true
+  still_duration: 1
+  pause_duration: 10
+  video_suffixes:
+    - "_HEVC"
+    - "-HEVC"
+    - ""
+  video_extensions:
+    - MOV
+    - mov
+    - mp4
+    - MP4
+  hide_companion_videos: true
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `live_photo.enabled` | boolean | `false` | Enable still+video pairing and playback |
+| `live_photo.still_duration` | number | `1` | Seconds to show the still before playing the companion video |
+| `live_photo.pause_duration` | number | `10` | Seconds to wait on the still after the companion video ends |
+| `live_photo.video_suffixes` | list | `["_HEVC", "-HEVC", ""]` | Suffixes to try when finding companion videos |
+| `live_photo.video_extensions` | list | `["MOV", "mov", "mp4", "MP4", "m4v", "M4V"]` | Companion video extensions to try |
+| `live_photo.hide_companion_videos` | boolean | `true` | Hide obvious companion videos from the normal slideshow queue |
 
 ## Interactive Actions
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -63,7 +63,7 @@ auto_advance_seconds: 60
 live_photo:
   enabled: true
   still_duration: 1
-  pause_duration: 10
+  repeat_delay: 10
   hide_companion_videos: true
 video_loop: false
 video_muted: true
@@ -97,7 +97,7 @@ media_type: all
 auto_advance_seconds: 60
 live_photo:
   still_duration: 1
-  pause_duration: 10
+  repeat_delay: 10
 ```
 
 | Option | Type | Default | Description |
@@ -467,13 +467,13 @@ When `auto_refresh_seconds > 0` and a video finishes playing:
 
 ## Live Photo Options
 
-Live Photos downloaded from iCloud are usually represented as a still image plus a companion video file. When enabled, the card treats the still image as the slideshow item, resolves the matching companion video, shows the still for a short moment, plays the video once, returns to the still, waits, and repeats while that slideshow item remains active.
+Live Photos downloaded from iCloud are usually represented as a still image plus a companion video file. When enabled, the card treats the still image as the slideshow item, resolves the matching companion video, keeps the still image visible, overlays the motion clip after a short delay, then returns to the still. This motion loop does not advance the slideshow; normal `auto_advance_seconds` timing still controls when the card moves to the next photo.
 
 ```yaml
 live_photo:
   enabled: true
   still_duration: 1
-  pause_duration: 10
+  repeat_delay: 10
   video_suffixes:
     - "_HEVC"
     - "-HEVC"
@@ -490,7 +490,8 @@ live_photo:
 |--------|------|---------|-------------|
 | `live_photo.enabled` | boolean | `false` | Enable still+video pairing and playback |
 | `live_photo.still_duration` | number | `1` | Seconds to show the still before playing the companion video |
-| `live_photo.pause_duration` | number | `10` | Seconds to wait on the still after the companion video ends |
+| `live_photo.repeat_delay` | number | `10` | Seconds to wait after the companion video ends before playing it again |
+| `live_photo.pause_duration` | number | `10` | Backward-compatible alias for `repeat_delay` |
 | `live_photo.video_suffixes` | list | `["_HEVC", "-HEVC", ""]` | Suffixes to try when finding companion videos |
 | `live_photo.video_extensions` | list | `["MOV", "mov", "mp4", "MP4", "m4v", "M4V"]` | Companion video extensions to try |
 | `live_photo.hide_companion_videos` | boolean | `true` | Hide obvious companion videos from the normal slideshow queue |

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -141,6 +141,26 @@ heic:
 | `heic.output_type` | string | `image/jpeg` | Converted image MIME type |
 | `heic.quality` | number | `0.92` | JPEG output quality passed to the converter |
 
+### Preload Options
+
+The card can prepare the selected photo or video before switching the visible layer. This helps limited hardware avoid partially painted large images and lets manual navigation obsolete stale work when a new button press arrives.
+
+```yaml
+type: custom:media-card
+preload:
+  enabled: true
+  image_decode: true
+  video_mode: metadata
+  video_timeout_ms: 3000
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `preload.enabled` | boolean | `true` | Prepare media before assigning it to the visible image/video layer |
+| `preload.image_decode` | boolean | `true` | Ask the browser to decode images off-DOM before display |
+| `preload.video_mode` | string | `metadata` | Video preparation mode: `metadata`, `canplay`, or `none` |
+| `preload.video_timeout_ms` | number | `3000` | Maximum time to wait for video preparation before displaying normally |
+
 ### Display Options
 
 | Option | Type | Default | Description |

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -483,6 +483,11 @@ live_photo:
     - mov
     - mp4
     - MP4
+  still_extensions:
+    - JPG
+    - jpg
+    - JPEG
+    - jpeg
   hide_companion_videos: true
 ```
 
@@ -494,6 +499,7 @@ live_photo:
 | `live_photo.pause_duration` | number | `10` | Backward-compatible alias for `repeat_delay` |
 | `live_photo.video_suffixes` | list | `["_HEVC", "-HEVC", ""]` | Suffixes to try when finding companion videos |
 | `live_photo.video_extensions` | list | `["MOV", "mov", "mp4", "MP4", "m4v", "M4V"]` | Companion video extensions to try |
+| `live_photo.still_extensions` | list | `["JPG", "jpg", "JPEG", "jpeg", "PNG", "png", "WEBP", "webp"]` | Still-image extensions used to identify plain same-basename companion videos |
 | `live_photo.hide_companion_videos` | boolean | `true` | Hide obvious companion videos from the normal slideshow queue |
 
 ## Interactive Actions

--- a/ha-media-card.js
+++ b/ha-media-card.js
@@ -4864,6 +4864,8 @@ class MediaCard extends LitElement {
     this._isLoadingNext = false;  // Re-entrance guard for _loadNext()
     this._isManualNavigation = false; // V5.6.7: Track if navigation is user-initiated vs timer-driven
     this._manualNavLoading = false;    // True from navigation commit until _onMediaLoaded/_onVideoCanPlay fires
+    this._swipeTouchStartX = null;    // Touch start X for swipe gesture detection
+    this._swipeTouchStartY = null;    // Touch start Y for swipe gesture detection
     
     // V5.6.0: Play randomized option for panels
     this._playRandomized = false;      // Toggle for randomizing panel playback order
@@ -13257,6 +13259,40 @@ class MediaCard extends LitElement {
     
     this._holdTriggered = false;
   }
+
+  _handleSwipeTouchStart(e) {
+    if (e.touches.length !== 1) return;
+    this._swipeTouchStartX = e.touches[0].clientX;
+    this._swipeTouchStartY = e.touches[0].clientY;
+  }
+
+  _handleSwipeTouchEnd(e) {
+    if (this._swipeTouchStartX === null) return;
+    const deltaX = e.changedTouches[0].clientX - this._swipeTouchStartX;
+    const deltaY = e.changedTouches[0].clientY - this._swipeTouchStartY;
+    this._swipeTouchStartX = null;
+    this._swipeTouchStartY = null;
+
+    // Require min horizontal distance and horizontal must dominate vertical
+    const SWIPE_THRESHOLD = 50;
+    if (Math.abs(deltaX) < SWIPE_THRESHOLD || Math.abs(deltaX) <= Math.abs(deltaY)) return;
+
+    // Horizontal swipe confirmed — suppress the synthetic click and hold action
+    e.preventDefault();
+    if (this._holdTimeout) {
+      clearTimeout(this._holdTimeout);
+      this._holdTimeout = null;
+    }
+
+    this._isManualNavigation = true;
+    if (deltaX > 0) {
+      // Swipe right → go back
+      this._loadPrevious();
+    } else {
+      // Swipe left → go forward
+      this._loadNext();
+    }
+  }
   
   _handlePointerUp(e) {
     if (this._holdTimeout) {
@@ -15903,6 +15939,8 @@ class MediaCard extends LitElement {
         @pointerdown=${this._handlePointerDown}
         @pointerup=${this._handlePointerUp}
         @pointercancel=${this._handlePointerCancel}
+        @touchstart=${this._handleSwipeTouchStart}
+        @touchend=${this._handleSwipeTouchEnd}
       >
         ${isVideo ? html`
           <video

--- a/ha-media-card.js
+++ b/ha-media-card.js
@@ -15964,9 +15964,10 @@ class MediaCard extends LitElement {
             @seeked=${this._onVideoSeeked}
             @volumechange=${this._onVideoVolumeChange}
             @click=${this._onVideoClickToggle}
-            @pointerdown=${(e) => { e.stopPropagation(); this._showButtonsExplicitly = true; this._startActionButtonsHideTimer(); this.requestUpdate(); }}
+            @dblclick=${this._handleDoubleTap}
+            @pointerdown=${(e) => { this._showButtonsExplicitly = true; this._startActionButtonsHideTimer(); this.requestUpdate(); }}
             @pointermove=${(e) => { e.stopPropagation(); this._showButtonsExplicitly = true; this._startActionButtonsHideTimer(); }}
-            @touchstart=${(e) => { e.stopPropagation(); this._showButtonsExplicitly = true; this._startActionButtonsHideTimer(); this.requestUpdate(); }}
+            @touchstart=${(e) => { this._showButtonsExplicitly = true; this._startActionButtonsHideTimer(); this.requestUpdate(); }}
           >
             <source src="${this.mediaUrl}" type="video/mp4" @error=${this._onSourceError}>
             <source src="${this.mediaUrl}" type="video/webm" @error=${this._onSourceError}>

--- a/ha-media-card.js
+++ b/ha-media-card.js
@@ -83,7 +83,6 @@ const MediaUtils = {
   }
 };
 
-
 /**
  * V5 Core Infrastructure Classes
  */
@@ -878,7 +877,6 @@ class MediaIndexHelper {
   }
 }
 
-
 /**
  * SingleMediaProvider - Provider for single image/video
  * Phase 2: Simplest provider to validate architecture
@@ -931,7 +929,6 @@ class SingleMediaProvider extends MediaProvider {
     this.currentItem = data.currentItem;
   }
 }
-
 
 /**
  * FOLDER PROVIDER - Wraps SubfolderQueue for folder slideshow
@@ -1473,8 +1470,6 @@ class FolderProvider extends MediaProvider {
   }
 
 }
-
-
 
 /**
  * SUBFOLDER QUEUE - Essential V4 code copied for v5
@@ -3043,7 +3038,6 @@ class SubfolderQueue {
  * Phase 2: Now uses provider pattern to display media
  */
 
-
 /**
  * MEDIA INDEX PROVIDER - Database-backed random media queries
  * V4 CODE REUSE: Copied from ha-media-card.js lines 2121-2250 (_queryMediaIndex)
@@ -3823,7 +3817,6 @@ class MediaIndexProvider extends MediaProvider {
     }
   }
 }
-
 
 /**
  * SEQUENTIAL MEDIA INDEX PROVIDER - Database-backed ordered queries
@@ -4674,8 +4667,6 @@ class SequentialMediaIndexProvider extends MediaProvider {
   }
 }
 
-
-
 /**
  * MediaCard - Main card component
  * Phase 2: Now uses provider pattern to display media
@@ -4767,6 +4758,41 @@ class MediaCard extends LitElement {
       show_metadata: true,
       enable_navigation_zones: true,
       title: 'Media Slideshow'
+    };
+  }
+
+  _applyICloudPhotosPreset(config) {
+    if (config?.icloud_photos?.enabled !== true) {
+      return config;
+    }
+
+    const icloudConfig = config.icloud_photos || {};
+    const basePath = icloudConfig.media_source_path || 'media-source://media_source/local/icloud_photos';
+    const album = icloudConfig.album || icloudConfig.photo_album || '';
+    const normalizedBasePath = basePath.replace(/\/$/, '');
+    const folderPath = album
+      ? `${normalizedBasePath}/${album}`
+      : normalizedBasePath;
+
+    return {
+      ...config,
+      media_source_type: 'folder',
+      media_type: config.media_type || 'all',
+      folder: {
+        mode: 'random',
+        recursive: true,
+        ...config.folder,
+        path: config.folder?.path || folderPath
+      },
+      live_photo: {
+        enabled: true,
+        still_duration: 1,
+        pause_duration: 10,
+        video_suffixes: ['_HEVC', '-HEVC', ''],
+        video_extensions: ['MOV', 'mov', 'mp4', 'MP4', 'm4v', 'M4V'],
+        hide_companion_videos: true,
+        ...config.live_photo
+      }
     };
   }
 
@@ -4918,6 +4944,13 @@ class MediaCard extends LitElement {
     this._userMutePreference = null;      // null=no preference, true=muted, false=unmuted
     this._mutePreferenceTimestamp = 0;    // When user last changed preference
     this._suppressVolumeChangeHandler = false; // V5.8: True during programmatic mute toggles (suppresses native-control detection)
+    
+    // Live Photo playback state. Used for iCloud-style still + companion video pairs.
+    this._livePhotoPhase = 'idle';        // idle | still | video | pause
+    this._livePhotoVideoUrl = '';
+    this._livePhotoTimer = null;
+    this._livePhotoCompanionCache = new Map();
+    this._livePhotoGeneration = 0;
 
     this._log('💎 Constructor called, cardId:', this._cardId);
   }
@@ -5069,6 +5102,9 @@ class MediaCard extends LitElement {
     
     // V5.6: Cleanup clock timer
     this._stopClockTimer();
+    
+    // Cleanup Live Photo playback timers
+    this._clearLivePhotoPlayback();
   }
 
   // V4: Force video reload when URL changes
@@ -5442,6 +5478,8 @@ class MediaCard extends LitElement {
       config = this._migrateV4ConfigToV5a(config);
       this._log('✅ V4 config migrated:', config);
     }
+
+    config = this._applyICloudPhotosPreset(config);
     
     // V5: Clear auto-advance timer when reconfiguring (prevents duplicate timers)
     if (this._refreshInterval) {
@@ -5449,6 +5487,7 @@ class MediaCard extends LitElement {
       clearInterval(this._refreshInterval);
       this._refreshInterval = null;
     }
+    this._clearLivePhotoPlayback();
     
     // V5: Validate and clamp max_height_pixels if present
     if (config.max_height_pixels !== undefined) {
@@ -5538,6 +5577,16 @@ class MediaCard extends LitElement {
         recent_change_window: 60, // seconds
         ...config.display_entities
       },
+      // V5.11: Live Photo pairing/playback for still + companion video exports
+      live_photo: {
+        enabled: false,
+        still_duration: 1,
+        pause_duration: 10,
+        video_suffixes: ['_HEVC', '-HEVC', ''],
+        video_extensions: ['MOV', 'mov', 'mp4', 'MP4', 'm4v', 'M4V'],
+        hide_companion_videos: true,
+        ...config.live_photo
+      },
       // V5.6: Clock/Date Overlay defaults
       clock: {
         enabled: false,
@@ -5556,7 +5605,15 @@ class MediaCard extends LitElement {
       // V5.6.12: Mute preference timeout (seconds) - how long user's mute choice persists
       mute_preference_timeout: config.mute_preference_timeout ?? 300,
       // V5.6.7: Edge fade strength (0 = disabled, 1-100 = enabled with fade intensity)
-      edge_fade_strength: config.edge_fade_strength ?? 0
+      edge_fade_strength: config.edge_fade_strength ?? 0,
+      // V5.11: iCloud Photos preset. Sync is handled server-side; the card owns display defaults.
+      icloud_photos: {
+        enabled: false,
+        media_source_path: 'media-source://media_source/local/icloud_photos',
+        album: '',
+        sync_backend: 'icloudpd',
+        ...config.icloud_photos
+      }
     };
     
     // V4: Set debug mode from config
@@ -6164,6 +6221,12 @@ class MediaCard extends LitElement {
           // arrived from another card while we were waiting for the provider.
           const _syncGenBefore = this._syncNavGeneration || 0;
           let item = await this.provider.getNext();
+          let hiddenCompanionAttempts = 0;
+          while (item && this._shouldHideLivePhotoCompanionVideo(item) && hiddenCompanionAttempts < 25) {
+            this._log('🎞️ Skipping Live Photo companion video in slideshow queue:', item.media_content_id);
+            item = await this.provider.getNext();
+            hiddenCompanionAttempts++;
+          }
         
           if (item) {
             this._log('Got item from provider:', item.filename || item.media_content_id);
@@ -6176,6 +6239,12 @@ class MediaCard extends LitElement {
             while (alreadyInQueue && attempts < maxAttempts) {
               this._log(`⚠️ Item already in navigation queue (attempt ${attempts + 1}), getting next:`, item.media_content_id);
               item = await this.provider.getNext();
+              hiddenCompanionAttempts = 0;
+              while (item && this._shouldHideLivePhotoCompanionVideo(item) && hiddenCompanionAttempts < 25) {
+                this._log('🎞️ Skipping Live Photo companion video in slideshow queue:', item.media_content_id);
+                item = await this.provider.getNext();
+                hiddenCompanionAttempts++;
+              }
               if (!item) break;
               alreadyInQueue = this.navigationQueue.some(q => q.media_content_id === item.media_content_id);
               attempts++;
@@ -6276,6 +6345,14 @@ class MediaCard extends LitElement {
         this._log('ERROR: No item at navigationIndex', nextIndex);
         return;
       }
+      
+      if (this._shouldHideLivePhotoCompanionVideo(item)) {
+        this._log('🎞️ Removing Live Photo companion video from navigation queue:', item.media_content_id);
+        this._removeItemFromQueues(item);
+        this._isLoadingNext = false;
+        setTimeout(() => this._loadNext(), 0);
+        return;
+      }
 
       // V5.6.8: Increment periodic refresh counter and check if refresh needed
       // Works for both sequential and random modes - provider handles mode-specific logic
@@ -6326,6 +6403,7 @@ class MediaCard extends LitElement {
       }
       
       // Display the item
+      this._clearLivePhotoPlayback();
       this.currentMedia = item;
       
       // V5.6.7: Store in pending state - will apply when image/video loads (syncs all overlays)
@@ -7815,6 +7893,16 @@ class MediaCard extends LitElement {
   }
   
   _onMediaError(e) {
+    if (this._livePhotoPhase === 'video') {
+      const itemId = this._getLivePhotoItemId(this.currentMedia);
+      if (itemId) this._livePhotoCompanionCache.set(itemId, null);
+      this._livePhotoPhase = 'idle';
+      this._livePhotoVideoUrl = '';
+      this._log('🎞️ Live Photo companion video failed - keeping still image visible');
+      this.requestUpdate();
+      return;
+    }
+
     // V5.6.7: Clear navigation flag to prevent slideshow getting stuck on 404 errors
     this._navigatingAway = false;
     
@@ -8143,6 +8231,205 @@ class MediaCard extends LitElement {
     }
   }
 
+  // V5.11: Live Photo helpers
+  _isLivePhotoEnabled() {
+    return this.config?.live_photo?.enabled === true;
+  }
+
+  _clearLivePhotoTimer() {
+    if (this._livePhotoTimer) {
+      clearTimeout(this._livePhotoTimer);
+      this._livePhotoTimer = null;
+    }
+  }
+
+  _clearLivePhotoPlayback() {
+    this._clearLivePhotoTimer();
+    this._livePhotoGeneration++;
+    this._livePhotoPhase = 'idle';
+    this._livePhotoVideoUrl = '';
+  }
+
+  _getLivePhotoItemId(item = this.currentMedia) {
+    return item?.media_content_id || item?.media_source_uri || item?.path || item?.metadata?.path || '';
+  }
+
+  _getLivePhotoFileName(itemOrPath) {
+    const path = typeof itemOrPath === 'string' ? itemOrPath : this._getLivePhotoItemId(itemOrPath);
+    const cleanPath = (path || '').split('?')[0].split('|')[0];
+    return cleanPath.split('/').pop() || cleanPath;
+  }
+
+  _getLivePhotoBaseName(itemOrPath) {
+    const filename = this._getLivePhotoFileName(itemOrPath);
+    const dotIndex = filename.lastIndexOf('.');
+    return dotIndex > 0 ? filename.substring(0, dotIndex) : filename;
+  }
+
+  _isImageItem(item) {
+    if (!item) return false;
+    if (item.media_content_type?.startsWith('image')) return true;
+    return MediaUtils.detectFileType(this._getLivePhotoItemId(item)) === 'image' ||
+           MediaUtils.detectFileType(item.title || '') === 'image';
+  }
+
+  _shouldHideLivePhotoCompanionVideo(item) {
+    if (!this._isLivePhotoEnabled() || this.config?.live_photo?.hide_companion_videos === false) {
+      return false;
+    }
+    if (!this._isVideoItem(item)) return false;
+
+    const baseName = this._getLivePhotoBaseName(item).toLowerCase();
+    const suffixes = this.config?.live_photo?.video_suffixes || ['_HEVC', '-HEVC'];
+    return suffixes
+      .filter(suffix => suffix && String(suffix).length > 0)
+      .some(suffix => baseName.endsWith(String(suffix).toLowerCase()));
+  }
+
+  _removeItemFromQueues(item) {
+    if (!item) return;
+    const itemId = item.media_content_id || item.media_source_uri || item.path;
+    const matches = (candidate) => {
+      const candidateId = candidate?.media_content_id || candidate?.media_source_uri || candidate?.path;
+      return candidate === item || (!!itemId && candidateId === itemId);
+    };
+
+    this.navigationQueue = (this.navigationQueue || []).filter(candidate => !matches(candidate));
+    this.history = (this.history || []).filter(candidate => !matches(candidate));
+    if (this._panelQueue?.length) {
+      this._panelQueue = this._panelQueue.filter(candidate => !matches(candidate));
+    }
+    if (this.provider?.queue?.length) {
+      this.provider.queue = this.provider.queue.filter(candidate => !matches(candidate));
+    }
+  }
+
+  _buildLivePhotoCompanionCandidates(item = this.currentMedia) {
+    const mediaId = this._getLivePhotoItemId(item);
+    if (!mediaId) return [];
+
+    const cleanId = mediaId.split('?')[0];
+    const slashIndex = cleanId.lastIndexOf('/');
+    const dotIndex = cleanId.lastIndexOf('.');
+    if (dotIndex <= slashIndex) return [];
+
+    const basePath = cleanId.substring(0, dotIndex);
+    const suffixes = this.config?.live_photo?.video_suffixes || ['_HEVC', '-HEVC', ''];
+    const extensions = this.config?.live_photo?.video_extensions || ['MOV', 'mov', 'mp4', 'MP4'];
+    const candidates = [];
+    const seen = new Set();
+
+    for (const suffix of suffixes) {
+      for (const extension of extensions) {
+        const candidate = `${basePath}${suffix || ''}.${extension}`;
+        if (!seen.has(candidate)) {
+          candidates.push(candidate);
+          seen.add(candidate);
+        }
+      }
+    }
+
+    return candidates;
+  }
+
+  async _resolveLivePhotoCompanion(item = this.currentMedia) {
+    const itemId = this._getLivePhotoItemId(item);
+    if (!itemId || !this.hass) return null;
+
+    if (this._livePhotoCompanionCache.has(itemId)) {
+      return this._livePhotoCompanionCache.get(itemId);
+    }
+
+    for (const candidate of this._buildLivePhotoCompanionCandidates(item)) {
+      const mediaContentId = candidate.startsWith('/media/')
+        ? `media-source://media_source${candidate}`
+        : candidate;
+
+      try {
+        const resolved = await this.hass.callWS({
+          type: 'media_source/resolve_media',
+          media_content_id: mediaContentId,
+          expires: (60 * 60 * 3)
+        });
+        const url = this._addCacheBustingTimestamp(resolved.url);
+        const companion = { media_content_id: mediaContentId, url };
+        this._livePhotoCompanionCache.set(itemId, companion);
+        this._log('🎞️ Live Photo companion resolved:', mediaContentId);
+        return companion;
+      } catch (error) {
+        this._log('🎞️ Live Photo companion candidate not available:', mediaContentId);
+      }
+    }
+
+    this._livePhotoCompanionCache.set(itemId, null);
+    return null;
+  }
+
+  _scheduleLivePhotoPlayback() {
+    this._clearLivePhotoTimer();
+
+    if (!this._isLivePhotoEnabled() ||
+        this._livePhotoPhase === 'pause' ||
+        !this._isImageItem(this.currentMedia) ||
+        this._isPaused ||
+        this._backgroundPaused ||
+        !this.mediaUrl) {
+      return;
+    }
+
+    const generation = ++this._livePhotoGeneration;
+    const itemId = this._getLivePhotoItemId(this.currentMedia);
+    this._livePhotoPhase = 'still';
+    const stillMs = Math.max(0.1, Number(this.config.live_photo?.still_duration) || 1) * 1000;
+
+    this._livePhotoTimer = setTimeout(() => {
+      this._startLivePhotoVideo(generation, itemId);
+    }, stillMs);
+  }
+
+  async _startLivePhotoVideo(generation, itemId) {
+    if (generation !== this._livePhotoGeneration ||
+        itemId !== this._getLivePhotoItemId(this.currentMedia) ||
+        this._isPaused ||
+        this._backgroundPaused) {
+      return;
+    }
+
+    const companion = await this._resolveLivePhotoCompanion(this.currentMedia);
+    if (!companion ||
+        generation !== this._livePhotoGeneration ||
+        itemId !== this._getLivePhotoItemId(this.currentMedia)) {
+      this._livePhotoPhase = 'idle';
+      return;
+    }
+
+    this._livePhotoVideoUrl = companion.url;
+    this._livePhotoPhase = 'video';
+    this._videoHasEnded = false;
+    this._videoTimerCount = 0;
+    this._videoPlayStartTime = null;
+    this.requestUpdate();
+  }
+
+  _onLivePhotoVideoEnded() {
+    if (this._livePhotoPhase !== 'video') return false;
+
+    this._clearLivePhotoTimer();
+    const generation = ++this._livePhotoGeneration;
+    const itemId = this._getLivePhotoItemId(this.currentMedia);
+    const pauseMs = Math.max(0, Number(this.config.live_photo?.pause_duration) || 10) * 1000;
+
+    this._livePhotoPhase = 'pause';
+    this._livePhotoVideoUrl = '';
+    this._hideBottomOverlaysForVideo = false;
+    this.requestUpdate();
+
+    this._livePhotoTimer = setTimeout(() => {
+      this._startLivePhotoVideo(generation, itemId);
+    }, pauseMs);
+    return true;
+  }
+
   // V4: Video event handlers
   _onVideoLoadStart() {
     this._log('Video load initiated:', this.mediaUrl);
@@ -8375,6 +8662,11 @@ class MediaCard extends LitElement {
   }
 
   _onVideoEnded() {
+    if (this._onLivePhotoVideoEnded()) {
+      this._log('🎞️ Live Photo motion clip ended - returning to still frame');
+      return;
+    }
+
     const endTime = new Date();
     this._log(`🎬 Video ended at ${endTime.toLocaleTimeString()}:`, this.mediaUrl);
     
@@ -9471,9 +9763,10 @@ class MediaCard extends LitElement {
     if (!this._isLocallyPaused()) {
       this._writeSharedQueueState();
     }
-
     // Cast-to-TV: push current item to TV on every image load
     this._pushCurrentToCast();
+
+    this._scheduleLivePhotoPlayback();
 
     // Trigger re-render to show updated metadata/counters
     this.requestUpdate();
@@ -15901,7 +16194,12 @@ class MediaCard extends LitElement {
       `;
     }
     
-    if (!this.mediaUrl) {
+    const displayUrl = this._livePhotoPhase === 'video' && this._livePhotoVideoUrl
+      ? this._livePhotoVideoUrl
+      : this.mediaUrl;
+    const livePhotoVideoActive = this._livePhotoPhase === 'video' && !!this._livePhotoVideoUrl;
+
+    if (!displayUrl) {
       return html`<div class="placeholder">Resolving media URL...</div>`;
     }
 
@@ -15913,8 +16211,9 @@ class MediaCard extends LitElement {
     // removed from the queue as a 404.
     // By using the resolved mediaUrl, the element type and src are always in sync.
     // Fallback: use media_content_type for extensionless URLs (e.g. Immich integration).
-    const resolvedUrlType = this.mediaUrl ? MediaUtils.detectFileType(this.mediaUrl) : null;
-    const isVideo = resolvedUrlType === 'video' ||
+    const resolvedUrlType = displayUrl ? MediaUtils.detectFileType(displayUrl) : null;
+    const isVideo = livePhotoVideoActive ||
+                    resolvedUrlType === 'video' ||
                     (resolvedUrlType !== 'image' && this.currentMedia?.media_content_type?.startsWith('video'));
 
     // Compute metadata overlay scale (defaults to 1.0; user configurable via metadata.scale)
@@ -15949,8 +16248,8 @@ class MediaCard extends LitElement {
             preload="auto"
             playsinline
             crossorigin="anonymous"
-            ?loop=${(this.config.video_loop || false) && !(this.config.auto_advance_seconds > 0)}
-            ?autoplay=${this.config.video_autoplay !== false}
+            ?loop=${!livePhotoVideoActive && (this.config.video_loop || false) && !(this.config.auto_advance_seconds > 0)}
+            ?autoplay=${livePhotoVideoActive || this.config.video_autoplay !== false}
             ?muted=${this._getEffectiveMuteState()}
             @loadstart=${this._onVideoLoadStart}
             @error=${this._onMediaError}
@@ -15969,16 +16268,16 @@ class MediaCard extends LitElement {
             @pointermove=${(e) => { e.stopPropagation(); this._showButtonsExplicitly = true; this._startActionButtonsHideTimer(); }}
             @touchstart=${(e) => { this._showButtonsExplicitly = true; this._startActionButtonsHideTimer(); this.requestUpdate(); }}
           >
-            <source src="${this.mediaUrl}" type="video/mp4" @error=${this._onSourceError}>
-            <source src="${this.mediaUrl}" type="video/webm" @error=${this._onSourceError}>
-            <source src="${this.mediaUrl}" type="video/ogg" @error=${this._onSourceError}>
-            <p>Your browser does not support the video tag. <a href="${this.mediaUrl}" target="_blank">Download the video</a> instead.</p>
+            <source src="${displayUrl}" type="video/mp4" @error=${this._onSourceError}>
+            <source src="${displayUrl}" type="video/webm" @error=${this._onSourceError}>
+            <source src="${displayUrl}" type="video/ogg" @error=${this._onSourceError}>
+            <p>Your browser does not support the video tag. <a href="${displayUrl}" target="_blank">Download the video</a> instead.</p>
           </video>
-          ${this._renderVideoInfo()}
+          ${livePhotoVideoActive ? html`` : this._renderVideoInfo()}
         ` : (this.config?.transition?.duration ?? 300) === 0 ? html`
           <!-- V5.6: Instant mode - single image, no layers -->
           <img 
-            src="${this.mediaUrl}" 
+            src="${displayUrl}" 
             alt="${this.currentMedia.title || 'Media'}"
             @error=${this._onMediaError}
             @load=${this._onMediaLoaded}
@@ -16579,7 +16878,6 @@ class MediaCard extends LitElement {
  * MediaCardEditor - Card editor with full functionality
  * Will be adapted for v5 architecture in next phase
  */
-
 
 /**
  * MediaCardEditor - Card editor with full functionality
@@ -20818,6 +21116,7 @@ Tip: Check your Home Assistant media folder in Settings > System > Storage`;
     `;
   }
 }
+
 // Register the custom elements (guard against re-registration)
 if (!customElements.get('media-card')) {
   customElements.define('media-card', MediaCard);

--- a/ha-media-card.js
+++ b/ha-media-card.js
@@ -4787,6 +4787,7 @@ class MediaCard extends LitElement {
       live_photo: {
         enabled: true,
         still_duration: 1,
+        repeat_delay: 10,
         pause_duration: 10,
         video_suffixes: ['_HEVC', '-HEVC', ''],
         video_extensions: ['MOV', 'mov', 'mp4', 'MP4', 'm4v', 'M4V'],
@@ -4948,6 +4949,7 @@ class MediaCard extends LitElement {
     // Live Photo playback state. Used for iCloud-style still + companion video pairs.
     this._livePhotoPhase = 'idle';        // idle | still | video | pause
     this._livePhotoVideoUrl = '';
+    this._livePhotoVideoReady = false;
     this._livePhotoTimer = null;
     this._livePhotoCompanionCache = new Map();
     this._livePhotoGeneration = 0;
@@ -5123,7 +5125,7 @@ class MediaCard extends LitElement {
     if (changedProperties.has('mediaUrl')) {
       // Wait for next frame to ensure video element is rendered
       requestAnimationFrame(() => {
-        const videoElement = this.shadowRoot?.querySelector('video');
+        const videoElement = this.shadowRoot?.querySelector('video:not(.live-photo-video)');
         
         if (videoElement && this.mediaUrl) {
           videoElement.load(); // Force browser to reload the video with new source
@@ -5581,6 +5583,7 @@ class MediaCard extends LitElement {
       live_photo: {
         enabled: false,
         still_duration: 1,
+        repeat_delay: 10,
         pause_duration: 10,
         video_suffixes: ['_HEVC', '-HEVC', ''],
         video_extensions: ['MOV', 'mov', 'mp4', 'MP4', 'm4v', 'M4V'],
@@ -6937,7 +6940,7 @@ class MediaCard extends LitElement {
           // - Short videos that loop: advance on FIRST timer fire after loop detected
           // - Long videos with max_duration: advance when timer count * interval >= max_duration
           // - Long videos without max_duration: never advance on timer (play to completion)
-          const videoElement = this.shadowRoot?.querySelector('video');
+          const videoElement = this.shadowRoot?.querySelector('video:not(.live-photo-video)');
           const maxDuration = this.config.video_max_duration;
           
           // Check if video is currently playing
@@ -7424,7 +7427,7 @@ class MediaCard extends LitElement {
           await this.updateComplete; // Wait for Lit to finish rendering
           
           // Check if it's a video or image and reload appropriately
-          const videoElement = this.shadowRoot?.querySelector('video');
+          const videoElement = this.shadowRoot?.querySelector('video:not(.live-photo-video)');
           const imgElement = this.shadowRoot?.querySelector('.media-container > img');
           
           if (videoElement) {
@@ -7733,7 +7736,7 @@ class MediaCard extends LitElement {
       // readyState > 0 means the OLD video has data, not that the NEW source is loading.
       // We MUST call load() to force browser to load the new source.
       await this.updateComplete;
-      const videoElement = this.shadowRoot?.querySelector('video');
+      const videoElement = this.shadowRoot?.querySelector('video:not(.live-photo-video)');
       if (videoElement) {
         this._log('🎬 Explicitly reloading video element for video→video transition');
         videoElement.load();
@@ -8248,6 +8251,7 @@ class MediaCard extends LitElement {
     this._livePhotoGeneration++;
     this._livePhotoPhase = 'idle';
     this._livePhotoVideoUrl = '';
+    this._livePhotoVideoReady = false;
   }
 
   _getLivePhotoItemId(item = this.currentMedia) {
@@ -8370,6 +8374,7 @@ class MediaCard extends LitElement {
 
     if (!this._isLivePhotoEnabled() ||
         this._livePhotoPhase === 'pause' ||
+        this._livePhotoPhase === 'video' ||
         !this._isImageItem(this.currentMedia) ||
         this._isPaused ||
         this._backgroundPaused ||
@@ -8404,23 +8409,56 @@ class MediaCard extends LitElement {
     }
 
     this._livePhotoVideoUrl = companion.url;
+    this._livePhotoVideoReady = false;
     this._livePhotoPhase = 'video';
-    this._videoHasEnded = false;
-    this._videoTimerCount = 0;
-    this._videoPlayStartTime = null;
     this.requestUpdate();
   }
 
-  _onLivePhotoVideoEnded() {
+  _getLivePhotoRepeatDelaySeconds() {
+    const repeatDelay = this.config.live_photo?.repeat_delay;
+    if (repeatDelay !== undefined && repeatDelay !== null) {
+      return Math.max(0, Number(repeatDelay) || 0);
+    }
+    return Math.max(0, Number(this.config.live_photo?.pause_duration) || 10);
+  }
+
+  _onLivePhotoVideoCanPlay(e) {
+    if (this._livePhotoPhase !== 'video') return;
+    this._livePhotoVideoReady = true;
+    const video = e?.target;
+    if (video && video.paused) {
+      video.play().catch(error => {
+        if (error?.name !== 'AbortError') {
+          this._log('🎞️ Live Photo autoplay failed:', error);
+        }
+      });
+    }
+    this.requestUpdate();
+  }
+
+  _onLivePhotoVideoError() {
+    if (this._livePhotoPhase !== 'video') return;
+    const itemId = this._getLivePhotoItemId(this.currentMedia);
+    if (itemId) this._livePhotoCompanionCache.set(itemId, null);
+    this._livePhotoPhase = 'still';
+    this._livePhotoVideoUrl = '';
+    this._livePhotoVideoReady = false;
+    this._log('🎞️ Live Photo companion video failed - keeping still image visible');
+    this.requestUpdate();
+  }
+
+  _onLivePhotoVideoEnded(e) {
+    e?.stopPropagation?.();
     if (this._livePhotoPhase !== 'video') return false;
 
     this._clearLivePhotoTimer();
     const generation = ++this._livePhotoGeneration;
     const itemId = this._getLivePhotoItemId(this.currentMedia);
-    const pauseMs = Math.max(0, Number(this.config.live_photo?.pause_duration) || 10) * 1000;
+    const pauseMs = this._getLivePhotoRepeatDelaySeconds() * 1000;
 
     this._livePhotoPhase = 'pause';
     this._livePhotoVideoUrl = '';
+    this._livePhotoVideoReady = false;
     this._hideBottomOverlaysForVideo = false;
     this.requestUpdate();
 
@@ -8526,7 +8564,7 @@ class MediaCard extends LitElement {
     
     // V5.6.4: Verify video element still exists in DOM before processing pause
     // Pause events can fire after navigation completes and video is removed
-    const videoElement = this.renderRoot?.querySelector('video');
+    const videoElement = this.renderRoot?.querySelector('video:not(.live-photo-video)');
     const isCurrentlyVideo = this._isVideoFile(this.currentMedia?.media_content_id || '');
     
     if (!videoElement || !isCurrentlyVideo) {
@@ -8614,7 +8652,7 @@ class MediaCard extends LitElement {
   // Based on V4 lines 3259-3302
   // V5 ENHANCEMENT: If user has interacted with video, ignore video_max_duration and play to end
   async _shouldWaitForVideoCompletion() {
-    const videoElement = this.renderRoot?.querySelector('video');
+    const videoElement = this.renderRoot?.querySelector('video:not(.live-photo-video)');
     
     // No video playing, don't wait
     if (!videoElement || !this.mediaUrl || this.currentMedia?.media_content_type?.startsWith('image')) {
@@ -8690,7 +8728,7 @@ class MediaCard extends LitElement {
       
       if (elapsedSeconds < autoAdvanceSeconds) {
         this._log(`🔁 Short video with loop enabled (${elapsedSeconds}s < ${autoAdvanceSeconds}s auto-advance) - restarting video`);
-        const videoElement = this.shadowRoot?.querySelector('video');
+        const videoElement = this.shadowRoot?.querySelector('video:not(.live-photo-video)');
         if (videoElement) {
           videoElement.currentTime = 0;
           videoElement.play().catch(err => this._log('Error restarting video:', err));
@@ -8807,7 +8845,7 @@ class MediaCard extends LitElement {
   }
 
   _onVideoLoadedMetadata() {
-    const video = this.shadowRoot?.querySelector('video');
+    const video = this.shadowRoot?.querySelector('video:not(.live-photo-video)');
     if (video) {
       // V5.6.12: Apply user mute preference if valid, otherwise use config default
       const shouldBeMuted = this._getEffectiveMuteState();
@@ -8870,7 +8908,7 @@ class MediaCard extends LitElement {
     this._log(`🔊 Mute toggled: ${currentEffective} → ${this._userMutePreference}`);
     
     // Apply to current video if one is playing
-    const video = this.shadowRoot?.querySelector('video');
+    const video = this.shadowRoot?.querySelector('video:not(.live-photo-video)');
     if (video) {
       video.muted = this._userMutePreference;
       
@@ -14094,6 +14132,24 @@ class MediaCard extends LitElement {
       opacity: 0;
       z-index: 1;
     }
+
+    .media-container .live-photo-video {
+      position: absolute;
+      inset: 0;
+      width: 100%;
+      height: 100%;
+      object-fit: contain;
+      object-position: center center;
+      opacity: 0;
+      z-index: 3;
+      pointer-events: none;
+      background: transparent;
+      transition: opacity 120ms ease-in-out;
+    }
+
+    .media-container .live-photo-video.ready {
+      opacity: 1;
+    }
     
     /* V5.7: Edge fade effect - smooth rectangular fade using intersecting gradients */
     :host([data-edge-fade]) img,
@@ -14198,6 +14254,10 @@ class MediaCard extends LitElement {
       max-height: none !important;
       object-fit: cover !important;
       object-position: center center;
+    }
+
+    :host([data-aspect-mode="viewport-fill"]) .media-container .live-photo-video {
+      object-fit: cover !important;
     }
     
     :host([data-aspect-mode="smart-scale"]) .media-container {
@@ -16194,9 +16254,7 @@ class MediaCard extends LitElement {
       `;
     }
     
-    const displayUrl = this._livePhotoPhase === 'video' && this._livePhotoVideoUrl
-      ? this._livePhotoVideoUrl
-      : this.mediaUrl;
+    const displayUrl = this.mediaUrl;
     const livePhotoVideoActive = this._livePhotoPhase === 'video' && !!this._livePhotoVideoUrl;
 
     if (!displayUrl) {
@@ -16212,8 +16270,7 @@ class MediaCard extends LitElement {
     // By using the resolved mediaUrl, the element type and src are always in sync.
     // Fallback: use media_content_type for extensionless URLs (e.g. Immich integration).
     const resolvedUrlType = displayUrl ? MediaUtils.detectFileType(displayUrl) : null;
-    const isVideo = livePhotoVideoActive ||
-                    resolvedUrlType === 'video' ||
+    const isVideo = resolvedUrlType === 'video' ||
                     (resolvedUrlType !== 'image' && this.currentMedia?.media_content_type?.startsWith('video'));
 
     // Compute metadata overlay scale (defaults to 1.0; user configurable via metadata.scale)
@@ -16248,8 +16305,8 @@ class MediaCard extends LitElement {
             preload="auto"
             playsinline
             crossorigin="anonymous"
-            ?loop=${!livePhotoVideoActive && (this.config.video_loop || false) && !(this.config.auto_advance_seconds > 0)}
-            ?autoplay=${livePhotoVideoActive || this.config.video_autoplay !== false}
+            ?loop=${(this.config.video_loop || false) && !(this.config.auto_advance_seconds > 0)}
+            ?autoplay=${this.config.video_autoplay !== false}
             ?muted=${this._getEffectiveMuteState()}
             @loadstart=${this._onVideoLoadStart}
             @error=${this._onMediaError}
@@ -16273,7 +16330,7 @@ class MediaCard extends LitElement {
             <source src="${displayUrl}" type="video/ogg" @error=${this._onSourceError}>
             <p>Your browser does not support the video tag. <a href="${displayUrl}" target="_blank">Download the video</a> instead.</p>
           </video>
-          ${livePhotoVideoActive ? html`` : this._renderVideoInfo()}
+          ${this._renderVideoInfo()}
         ` : (this.config?.transition?.duration ?? 300) === 0 ? html`
           <!-- V5.6: Instant mode - single image, no layers -->
           <img 
@@ -16302,6 +16359,21 @@ class MediaCard extends LitElement {
               @load=${this._onMediaLoaded}
             />
           ` : ''}
+        ` : ''}
+        ${livePhotoVideoActive ? html`
+          <video
+            class="live-photo-video ${this._livePhotoVideoReady ? 'ready' : ''}"
+            preload="auto"
+            playsinline
+            autoplay
+            muted
+            crossorigin="anonymous"
+            src="${this._livePhotoVideoUrl}"
+            @canplay=${this._onLivePhotoVideoCanPlay}
+            @playing=${this._onLivePhotoVideoCanPlay}
+            @ended=${this._onLivePhotoVideoEnded}
+            @error=${this._onLivePhotoVideoError}
+          ></video>
         ` : ''}
         ${this._renderNavigationZones()}
         ${this._renderMetadataOverlay()}
@@ -21138,7 +21210,7 @@ if (!window.customCards.some(card => card.type === 'media-card')) {
 }
 
 console.info(
-  '%c  MEDIA-CARD  %c  v5.10.0 Loaded  ',
+  '%c  MEDIA-CARD  %c  v__VERSION__ Loaded  ',
   'color: lime; font-weight: bold; background: black',
   'color: white; font-weight: bold; background: green'
 );

--- a/ha-media-card.js
+++ b/ha-media-card.js
@@ -6,9 +6,9 @@
 (async () => {
   // Default CDN URL for Lit
   const LIT_CDN_URL = 'https://cdn.jsdelivr.net/gh/lit/dist@3/core/lit-core.min.js';
-  
+
   let LitElement, html, css;
-  
+
   // Check if Lit was preloaded globally (for offline support)
   if (window.LitElement && window.html && window.css) {
     console.log('[Media Card] Using preloaded Lit from window');
@@ -47,7 +47,6 @@
       return; // Can't continue without Lit
     }
   }
-
 // Shared utility functions for media detection
 const MediaUtils = {
   detectFileType(filePath) {
@@ -738,7 +737,6 @@ class MediaProvider {
     this.isPaused = data.isPaused || false;
   }
 }
-
 /**
  * MediaIndexHelper - Shared utility for media_index integration
  * V5: Provides unified metadata fetching for all providers
@@ -7906,7 +7904,7 @@ class MediaCard extends LitElement {
     // V5.6.7: Guard against stale async resolutions during rapid navigation
     // If expectedNavigationIndex is provided and doesn't match current pending index, abort
     if (!this._isNavigationCurrent(expectedNavigationIndex, expectedGeneration)) {
-      this._log(`⏭️ Skipping stale media resolution (expected: ${expectedNavigationIndex}, current: ${this._pendingNavigationIndex})`);
+      this._log(`⏭️ Skipping stale media resolution (expected index: ${expectedNavigationIndex}, current index: ${this._pendingNavigationIndex}, expected generation: ${expectedGeneration}, current generation: ${this._navigationGeneration})`);
       // Clear the navigation-in-progress flag when nothing else has claimed a pending
       // path (i.e. no sync nav or newer _loadNext() is in flight). Without this,
       // a stale return from a _loadNext() call that was superseded by a rapid sync
@@ -8227,13 +8225,9 @@ class MediaCard extends LitElement {
   }
   
   _onMediaError(e) {
-    if (this._livePhotoPhase === 'video') {
-      const itemId = this._getLivePhotoItemId(this.currentMedia);
-      if (itemId) this._livePhotoCompanionCache.delete(itemId);
-      this._livePhotoPhase = 'idle';
-      this._livePhotoVideoUrl = '';
-      this._log('🎞️ Live Photo companion video failed - keeping still image visible');
-      this.requestUpdate();
+    const target = e?.target;
+    if (this._livePhotoPhase === 'video' && target?.classList?.contains('live-photo-video')) {
+      this._onLivePhotoVideoError(e);
       return;
     }
 
@@ -8241,7 +8235,6 @@ class MediaCard extends LitElement {
     this._navigatingAway = false;
     
     // V4 comprehensive error handling
-    const target = e.target;
     const error = target?.error;
     
     let errorMessage = 'Media file not found';
@@ -8646,11 +8639,17 @@ class MediaCard extends LitElement {
     const itemId = this._getLivePhotoItemId(item);
     if (!itemId || !this.hass) return false;
 
-    if (this._livePhotoCompanionVideoCache.get(itemId) === true) {
-      return true;
+    if (this._livePhotoCompanionVideoCache.has(itemId)) {
+      return this._livePhotoCompanionVideoCache.get(itemId) === true;
     }
 
-    for (const candidate of this._buildLivePhotoStillCandidatesForVideo(item)) {
+    const candidates = this._buildLivePhotoStillCandidatesForVideo(item);
+    if (!candidates.length) {
+      this._livePhotoCompanionVideoCache.set(itemId, false);
+      return false;
+    }
+
+    for (const candidate of candidates) {
       const mediaContentId = candidate.startsWith('/media/')
         ? `media-source://media_source${candidate}`
         : candidate;
@@ -8668,6 +8667,7 @@ class MediaCard extends LitElement {
       }
     }
 
+    this._livePhotoCompanionVideoCache.set(itemId, false);
     return false;
   }
 
@@ -21697,7 +21697,6 @@ Tip: Check your Home Assistant media folder in Settings > System > Storage`;
     `;
   }
 }
-
 // Register the custom elements (guard against re-registration)
 if (!customElements.get('media-card')) {
   customElements.define('media-card', MediaCard);
@@ -21719,7 +21718,7 @@ if (!window.customCards.some(card => card.type === 'media-card')) {
 }
 
 console.info(
-  '%c  MEDIA-CARD  %c  v__VERSION__ Loaded  ',
+  '%c  MEDIA-CARD  %c  v5.10.0 Loaded  ',
   'color: lime; font-weight: bold; background: black',
   'color: white; font-weight: bold; background: green'
 );

--- a/ha-media-card.js
+++ b/ha-media-card.js
@@ -8781,9 +8781,66 @@ class MediaCard extends LitElement {
     this._livePhotoPhase = 'still';
     const stillMs = Math.max(0.1, Number(this.config.live_photo?.still_duration) || 1) * 1000;
 
+    this._warmLivePhotoCompanion(generation, itemId);
+
     this._livePhotoTimer = setTimeout(() => {
       this._startLivePhotoVideo(generation, itemId);
     }, stillMs);
+  }
+
+  async _warmLivePhotoCompanion(generation, itemId) {
+    try {
+      const companion = await this._resolveLivePhotoCompanion(this.currentMedia);
+      if (!companion ||
+          generation !== this._livePhotoGeneration ||
+          itemId !== this._getLivePhotoItemId(this.currentMedia) ||
+          this.config?.live_photo?.preload_video === false) {
+        return;
+      }
+      await this._preloadLivePhotoVideo(companion.url, generation, itemId);
+    } catch (error) {
+      this._log('🎞️ Live Photo warmup skipped:', error?.message || error);
+    }
+  }
+
+  async _preloadLivePhotoVideo(url, generation, itemId) {
+    if (!url || typeof document === 'undefined') return;
+
+    await new Promise(resolve => {
+      const video = document.createElement('video');
+      let settled = false;
+      const cleanup = () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeout);
+        video.removeEventListener('loadedmetadata', onReady);
+        video.removeEventListener('canplay', onReady);
+        video.removeEventListener('error', onDone);
+        video.removeAttribute('src');
+        video.load?.();
+        resolve();
+      };
+      const isCurrent = () =>
+        generation === this._livePhotoGeneration &&
+        itemId === this._getLivePhotoItemId(this.currentMedia);
+      const onReady = () => cleanup();
+      const onDone = () => cleanup();
+      const timeout = setTimeout(cleanup, 3000);
+
+      if (!isCurrent()) {
+        cleanup();
+        return;
+      }
+
+      video.preload = 'auto';
+      video.muted = true;
+      video.playsInline = true;
+      video.addEventListener('loadedmetadata', onReady, { once: true });
+      video.addEventListener('canplay', onReady, { once: true });
+      video.addEventListener('error', onDone, { once: true });
+      video.src = url;
+      video.load();
+    });
   }
 
   async _startLivePhotoVideo(generation, itemId) {

--- a/ha-media-card.js
+++ b/ha-media-card.js
@@ -3849,6 +3849,7 @@ class SequentialMediaIndexProvider extends MediaProvider {
     // Prevents further navigation attempts and unnecessary service calls
     this.reachedEnd = false;
     this.disableAutoLoop = false; // V5.3: Prevent auto-loop during pre-load
+    this._dbCleanupWarningShown = false; // Show DB cleanup warning at most once per session
   }
 
   _log(...args) {
@@ -3965,7 +3966,9 @@ class SequentialMediaIndexProvider extends MediaProvider {
       this.lastSeenValue = null;
       this.reachedEnd = false;
       this.hasMore = true;
-      this.excludedFiles.clear(); // Clear excluded files when looping back
+      // Don't clear 404 exclusions on loop-back — files missing from disk stay missing.
+      // Keeping them in excludedFiles lets _queryOrderedFiles() skip past them efficiently
+      // on the next pass instead of re-fetching the same stale DB entries.
       
       const items = await this._queryOrderedFiles();
       if (items && items.length > 0) {
@@ -3986,6 +3989,18 @@ class SequentialMediaIndexProvider extends MediaProvider {
       while (item && this._isExcluded(item.path)) {
         this._log(`⏭️ Skipping excluded file in getNext: ${item.path}`);
         if (this.queue.length === 0) {
+          if (this.hasMore && !this.reachedEnd) {
+            // Queue drained by 404-skipping before the top-of-function low-water refill fired.
+            // Fetch the next batch now rather than returning null and triggering a cursor reset.
+            this._log('⚠️ Queue empty while skipping excluded files — fetching next batch...');
+            const moreItems = await this._queryOrderedFiles();
+            if (moreItems && moreItems.length > 0) {
+              this.queue.push(...moreItems);
+              item = this.queue.shift();
+              if (!item) break;
+              continue;
+            }
+          }
           this._log('⚠️ Queue exhausted while skipping excluded files');
           return null;
         }
@@ -4082,6 +4097,7 @@ class SequentialMediaIndexProvider extends MediaProvider {
       // folder won't halt iteration; only a pathological config (everything excluded) will stop it.
       let consecutiveAllExcludedBatches = 0;
       const MAX_CONSECUTIVE_EXCLUDED = 20; // Give up after 20 fully-excluded batches in a row
+      const DB_CLEANUP_WARNING_THRESHOLD = 5; // Warn user after 5 consecutive fully-excluded batches (1250+ missing files)
       // Overall iteration cap: limits worst-case WebSocket calls when excluded_paths leaves
       // only a few valid items per batch (not all-excluded, so consecutive counter keeps resetting).
       // 20 iterations × queueSize items/batch gives a reasonable upper bound on backend load.
@@ -4241,6 +4257,13 @@ class SequentialMediaIndexProvider extends MediaProvider {
         const validFromThisBatch = filteredItems.length;
         if (validFromThisBatch === 0 && response.items.length > 0) {
           consecutiveAllExcludedBatches++;
+          if (consecutiveAllExcludedBatches >= DB_CLEANUP_WARNING_THRESHOLD && !this._dbCleanupWarningShown) {
+            this._dbCleanupWarningShown = true;
+            const missingCount = consecutiveAllExcludedBatches * this.queueSize;
+            const warningMsg = `⚠️ Media Index: ${missingCount}+ missing files detected in database. Run the cleanup_database service to remove stale entries.`;
+            console.warn(`[SequentialMediaIndexProvider] ${warningMsg}`);
+            this.card?._showToast(warningMsg, 7000);
+          }
           if (consecutiveAllExcludedBatches >= MAX_CONSECUTIVE_EXCLUDED) {
             this._log(`⚠️ Stopping after ${MAX_CONSECUTIVE_EXCLUDED} consecutive fully-excluded batches - excluded_paths may be too broad`);
             break;
@@ -13276,7 +13299,7 @@ class MediaCard extends LitElement {
     }
   }
 
-  _showToast(message) {
+  _showToast(message, duration = 2000) {
     // V4 CODE: Simple toast notification (line 5470-5492)
     const toast = document.createElement('div');
     toast.textContent = message;
@@ -13298,7 +13321,7 @@ class MediaCard extends LitElement {
     
     setTimeout(() => {
       toast.remove();
-    }, 2000);
+    }, duration);
   }
 
   // NEW: Auto-enable kiosk mode monitoring

--- a/ha-media-card.js
+++ b/ha-media-card.js
@@ -4786,6 +4786,10 @@ class MediaCard extends LitElement {
     this._editorPreview = false; // V5.5: Flag to indicate card is in config editor preview
     this._cachedHeaderElement = null; // V5.6: Cached HA header element for viewport height calculation
     this._cachedHeaderSelector = null; // V5.6: Selector that found the cached header
+
+    // Cast-to-TV state
+    this._castEntityId = null;     // media_player entity currently mirroring this card
+    this._castPauseTimer = null;   // setTimeout handle for pre-end pause
     
     // V5.5: Side Panel System (Burst Review & Queue Preview)
     // Panel state
@@ -4943,7 +4947,11 @@ class MediaCard extends LitElement {
 
   disconnectedCallback() {
     super.disconnectedCallback();
-    
+
+    // Stop any active cast so the TV doesn't show a frozen image after the
+    // card is removed or the user navigates away.
+    if (this._castEntityId) this._stopCast();
+
     this._log('🔌 Component disconnected - cleaning up resources');
     
     // NEW: Cleanup kiosk mode monitoring
@@ -8150,7 +8158,10 @@ class MediaCard extends LitElement {
     if (!this._isLocallyPaused()) {
       this._writeSharedQueueState();
     }
-    
+
+    // Cast-to-TV: push current item to TV on every video ready
+    this._pushCurrentToCast();
+
     this.requestUpdate();
   }
 
@@ -8585,8 +8596,12 @@ class MediaCard extends LitElement {
   }
 
   // Is cross-device sync available?
+  _getEffectiveSyncGroupId() {
+    return this.config?.shared_queue_id || null;
+  }
+
   _hasCrossDeviceSync() {
-    return !!(this.config?.shared_queue_id && this._getMediaIndexEntityId() && this.hass);
+    return !!(this._getEffectiveSyncGroupId() && this._getMediaIndexEntityId() && this.hass);
   }
 
   // ── Write path ──────────────────────────────────────────────────────────────
@@ -8595,7 +8610,7 @@ class MediaCard extends LitElement {
   // must NOT set it, otherwise Device B's navigation will overwrite Device A's local
   // pause state.
   _writeSharedQueueState(pauseIntent = false) {
-    const id = this.config?.shared_queue_id;
+    const id = this._getEffectiveSyncGroupId();
     if (!id || !this.navigationQueue?.length) return;
 
     // Echo-prevention: skip the write that would bounce an incoming navigation sync
@@ -8652,7 +8667,7 @@ class MediaCard extends LitElement {
   }
 
   async _writeSharedQueueStateToMediaIndex(pauseIntent = false) {
-    const id = this.config?.shared_queue_id;
+    const id = this._getEffectiveSyncGroupId();
     if (!id || !this.navigationQueue?.length) return;
     try {
       const entityId = this._getMediaIndexEntityId();
@@ -9416,7 +9431,10 @@ class MediaCard extends LitElement {
     if (!this._isLocallyPaused()) {
       this._writeSharedQueueState();
     }
-    
+
+    // Cast-to-TV: push current item to TV on every image load
+    this._pushCurrentToCast();
+
     // Trigger re-render to show updated metadata/counters
     this.requestUpdate();
   }
@@ -9926,8 +9944,9 @@ class MediaCard extends LitElement {
       : mediaType !== 'image';
     
     // Don't render anything if all buttons are disabled
+    const enableCast = this.config?.show_cast_button === true;
     const anyButtonEnabled = enablePause || showMuteButton || enableDebugButton || enableRefresh || enableFullscreen || 
-                            (showMediaIndexButtons && (enableFavorite || enableDelete || enableEdit || enableInfo || enableBurstReview || enableRelatedPhotos || enableOnThisDay)) ||
+                            (showMediaIndexButtons && (enableFavorite || enableDelete || enableEdit || enableInfo || enableBurstReview || enableRelatedPhotos || enableOnThisDay || enableCast)) ||
                             showQueueButton;
     if (!anyButtonEnabled) {
       return html``;
@@ -10056,6 +10075,14 @@ class MediaCard extends LitElement {
             @click=${this._handleDeleteClick}
             title="Delete">
             <ha-icon icon="mdi:delete-outline"></ha-icon>
+          </button>
+        ` : ''}
+        ${showMediaIndexButtons && this.config?.show_cast_button === true ? html`
+          <button
+            class="action-btn cast-btn ${this._castEntityId ? 'active' : ''}"
+            @click=${this._handleCastButtonClick}
+            title="${this._castEntityId ? `Casting to ${this._castEntityId} (tap to stop)` : 'Cast to TV'}">
+            <ha-icon icon="${this._castEntityId ? 'mdi:cast-connected' : 'mdi:cast'}"></ha-icon>
           </button>
         ` : ''}
       </div>
@@ -11315,6 +11342,209 @@ class MediaCard extends LitElement {
     const thumbnailUrl = await this._getMediaThumbnail(targetPath);
     
     this._showDeleteConfirmation(targetPath, thumbnailUrl, filename);
+  }
+
+  // ── Cast-to-TV handlers ────────────────────────────────────────────────────
+
+  async _handleCastButtonClick(e) {
+    e.stopPropagation();
+    if (this._castEntityId) {
+      this._stopCast();
+    } else {
+      await this._showCastPicker();
+    }
+  }
+
+  _showCastPicker() {
+    if (!this.hass) return;
+
+    const players = Object.entries(this.hass.states)
+      .filter(([id]) => id.startsWith('media_player.'))
+      .map(([id, state]) => ({
+        entity_id: id,
+        friendly_name: state.attributes?.friendly_name || id,
+        state: state.state,
+        is_roku: 'app_id' in (state.attributes || {}),
+      }))
+      .sort((a, b) => {
+        // Roku devices first, then alphabetical
+        if (a.is_roku !== b.is_roku) return a.is_roku ? -1 : 1;
+        return a.friendly_name.localeCompare(b.friendly_name);
+      });
+
+    if (!players.length) return;
+
+    const dialog = document.createElement('div');
+    dialog.className = 'cast-picker-overlay';
+    dialog.innerHTML = `
+      <div class="cast-picker-content">
+        <h3 class="cast-picker-title">Cast to…</h3>
+        <div class="cast-picker-list">
+          ${players.map(p => `
+            <button class="cast-picker-item${p.is_roku ? ' cast-picker-item--roku' : ''}" data-entity="${p.entity_id}">
+              <span class="cast-picker-name">${p.friendly_name}</span>
+              <span class="cast-picker-status">${p.state}${p.is_roku ? ' · Roku' : ''}</span>
+            </button>
+          `).join('')}
+        </div>
+        <button class="cast-picker-cancel">Cancel</button>
+      </div>
+    `;
+
+    const card = this.shadowRoot.querySelector('.card');
+    card.appendChild(dialog);
+
+    const cleanup = () => dialog.remove();
+    dialog.querySelector('.cast-picker-cancel').addEventListener('click', cleanup);
+    // Tap outside the content panel to dismiss
+    dialog.addEventListener('click', e => { if (e.target === dialog) cleanup(); });
+
+    dialog.querySelectorAll('.cast-picker-item').forEach(btn => {
+      btn.addEventListener('click', () => {
+        cleanup();
+        this._castEntityId = btn.dataset.entity;
+        this.requestUpdate();
+        // Send immediately to launch xcast (or update if already running).
+        // Then retry after 2.5 s — if xcast was cold-starting the first send
+        // wakes it up and the retry arrives once it's ready to display content.
+        this._pushCurrentToCast();
+        setTimeout(() => this._pushCurrentToCast(), 2500);
+      });
+    });
+  }
+
+  _stopCast() {
+    const entityId = this._castEntityId;
+    const isRoku = entityId && 'app_id' in (this.hass?.states[entityId]?.attributes || {});
+
+    this._castEntityId = null;
+    // Cancel any pending pre-end pause
+    if (this._castPauseTimer) {
+      clearTimeout(this._castPauseTimer);
+      this._castPauseTimer = null;
+    }
+    this.requestUpdate();
+
+    // Tell the Roku to stop via ECP keypress/Home — this sends it back to the
+    // home screen so the last cast image doesn't appear frozen on the TV.
+    // We use our own backend service because the Roku HA entity does not
+    // support the generic media_player.media_stop action.
+    if (isRoku && this.hass) {
+      this.hass.callService('media_index', 'stop_cast', { roku_entity_id: entityId }).catch(() => {});
+    }
+  }
+
+  async _pushCurrentToCast() {
+    if (!this._castEntityId || !this.hass || !this._currentMediaPath) return;
+
+    // Cancel any pre-end pause from the previous item
+    if (this._castPauseTimer) {
+      clearTimeout(this._castPauseTimer);
+      this._castPauseTimer = null;
+    }
+
+    const uri = this._currentMediaPath;
+    const entityId = this._castEntityId;
+    const fileType = MediaUtils.detectFileType(uri);
+    const ext = (uri.split('?')[0].split('.').pop() || '').toLowerCase();
+    const filename = uri.split('/').pop().split('?')[0];
+
+    // Resolve media-source:// URIs to a signed HTTP URL
+    let url = uri;
+    if (uri.startsWith('media-source://')) {
+      try {
+        const resp = await this.hass.callWS({
+          type: 'media_source/resolve_media',
+          media_content_id: uri,
+          expires: 3600,
+        });
+        if (resp?.url) url = resp.url;
+      } catch (err) {
+        this._log('⚠️ Cast: could not resolve media URL:', err);
+      }
+    }
+
+    // Detect Roku: Roku media_player entities have an app_id attribute
+    const playerAttrs = this.hass.states[entityId]?.attributes || {};
+    const isRoku = 'app_id' in playerAttrs;
+
+    if (isRoku) {
+      // Roku: use media_index.roku_ecp_cast which runs the xcast ECP call server-side.
+      // Direct browser→Roku ECP is blocked by CORS; this service bypasses that.
+      // xcast (app 687485) supports both video and images with automatic orientation.
+      const castData = {
+        roku_entity_id: entityId,
+      };
+      // Identify the file — prefer media_source_uri (exact match), then fs path, then filename substring
+      if (this._currentMetadata?.media_source_uri) {
+        castData.media_source_uri = this._currentMetadata.media_source_uri;
+      } else if (this._currentMetadata?.path) {
+        castData.file_path = this._currentMetadata.path;
+      } else {
+        castData.path_contains = filename;
+      }
+
+      // Route to the correct media_index instance (same pattern as get_random_items)
+      const wsCall = {
+        type: 'call_service',
+        domain: 'media_index',
+        service: 'roku_ecp_cast',
+        service_data: castData,
+        return_response: true,
+      };
+      if (this.config.media_index?.entity_id) {
+        wsCall.target = { entity_id: this.config.media_index.entity_id };
+      }
+
+      this._log(`🎬 Cast (Roku xcast) → ${entityId}: type=${fileType}, ${uri}`);
+      try {
+        const castResp = await this.hass.callWS(wsCall);
+        const r = castResp?.response ?? castResp;
+        this._log(`🎬 Cast (Roku xcast) cmd: ${r?.ecp_url_sent} → HTTP ${r?.ecp_status}`);
+      } catch (err) {
+        this._log('⚠️ Cast: roku_ecp_cast failed:', err);
+        return;
+      }
+    } else {
+      // DLNA / DMR / LG WebOS etc: proper MIME type required
+      const mimeMap = {
+        mp4: 'video/mp4', mov: 'video/quicktime', m4v: 'video/x-m4v',
+        avi: 'video/x-msvideo', mkv: 'video/x-matroska', wmv: 'video/x-ms-wmv',
+        webm: 'video/webm', ogv: 'video/ogg', '3gp': 'video/3gpp',
+        jpg: 'image/jpeg', jpeg: 'image/jpeg', png: 'image/png',
+        gif: 'image/gif', webp: 'image/webp', heic: 'image/heic',
+        bmp: 'image/bmp', tiff: 'image/tiff', tif: 'image/tiff',
+      };
+      const mimeType = mimeMap[ext] || (fileType === 'video' ? 'video/mp4' : 'image/jpeg');
+      const serviceData = {
+        entity_id: entityId,
+        media_content_id: url,
+        media_content_type: mimeType,
+      };
+      this._log(`🎬 Cast (DMR) → ${entityId}: ${mimeType} ${uri}`);
+      try {
+        await this.hass.callService('media_player', 'play_media', serviceData);
+      } catch (err) {
+        this._log('⚠️ Cast: play_media failed:', err);
+        return;
+      }
+    }
+
+    // Schedule a pre-end pause for videos so the TV doesn't snap to home screen
+    if (fileType === 'video') {
+      const duration = this._currentMetadata?.duration;
+      if (duration && parseFloat(duration) > 2) {
+        const pauseAfterMs = Math.max(1000, (parseFloat(duration) - 2) * 1000);
+        this._castPauseTimer = setTimeout(async () => {
+          this._castPauseTimer = null;
+          if (this._castEntityId !== entityId) return;
+          try {
+            await this.hass.callService('media_player', 'media_pause', { entity_id: entityId });
+            this._log(`🎬 Cast: pre-end pause sent to ${entityId}`);
+          } catch (_) {}
+        }, pauseAfterMs);
+      }
+    }
   }
 
   // V5.2: _convertToFilesystemPath removed - Media Index v1.1.0+ accepts media_source_uri directly
@@ -14618,7 +14848,112 @@ class MediaCard extends LitElement {
     .confirm-btn:hover {
       background: var(--error-color-dark, #d32f2f);
     }
-    
+
+    /* ── Cast Picker Dialog ─────────────────────────────────────────────────── */
+    .cast-picker-overlay {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background: rgba(0, 0, 0, 0.7);
+      backdrop-filter: blur(4px);
+      z-index: 1000;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .cast-picker-content {
+      background: rgba(30, 30, 30, 0.92);
+      backdrop-filter: blur(20px);
+      -webkit-backdrop-filter: blur(20px);
+      border: 1px solid rgba(255, 255, 255, 0.12);
+      border-radius: 14px;
+      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.8);
+      min-width: 280px;
+      max-width: 420px;
+      width: 90%;
+      padding: 20px 16px 16px;
+      animation: dialogSlideIn 0.25s ease;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+
+    .cast-picker-title {
+      margin: 0 0 4px;
+      font-size: 15px;
+      font-weight: 600;
+      color: rgba(255, 255, 255, 0.9);
+      text-align: center;
+      letter-spacing: 0.3px;
+    }
+
+    .cast-picker-list {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      max-height: 320px;
+      overflow-y: auto;
+    }
+
+    .cast-picker-item {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      padding: 10px 14px;
+      border-radius: 10px;
+      border: 1px solid rgba(255, 255, 255, 0.1);
+      background: rgba(255, 255, 255, 0.06);
+      color: white;
+      cursor: pointer;
+      text-align: left;
+      transition: background 0.15s ease;
+    }
+
+    .cast-picker-item:hover {
+      background: rgba(255, 255, 255, 0.14);
+      border-color: rgba(255, 255, 255, 0.22);
+    }
+
+    .cast-picker-item--roku {
+      border-color: rgba(100, 200, 100, 0.35);
+      background: rgba(100, 200, 100, 0.08);
+    }
+
+    .cast-picker-item--roku:hover {
+      background: rgba(100, 200, 100, 0.18);
+    }
+
+    .cast-picker-name {
+      font-size: 14px;
+      font-weight: 500;
+    }
+
+    .cast-picker-status {
+      font-size: 11px;
+      opacity: 0.55;
+      margin-top: 1px;
+    }
+
+    .cast-picker-cancel {
+      margin-top: 4px;
+      padding: 9px;
+      border-radius: 10px;
+      border: 1px solid rgba(255, 255, 255, 0.1);
+      background: rgba(255, 255, 255, 0.06);
+      color: rgba(255, 255, 255, 0.6);
+      cursor: pointer;
+      font-size: 13px;
+      transition: background 0.15s ease;
+    }
+
+    .cast-picker-cancel:hover {
+      background: rgba(255, 255, 255, 0.12);
+      color: rgba(255, 255, 255, 0.9);
+    }
+
     /* Info Overlay Styles - Modern dropdown design */
     .info-overlay {
       position: absolute;
@@ -17508,6 +17843,13 @@ class MediaCardEditor extends LitElement {
     this._fireConfigChanged();
   }
 
+  _showCastButtonChanged(ev) {
+    this._config = ev.target.checked
+      ? { ...this._config, show_cast_button: true }
+      : (() => { const c = { ...this._config }; delete c.show_cast_button; return c; })();
+    this._fireConfigChanged();
+  }
+
   _actionButtonsEnableQueuePreviewChanged(ev) {
     this._config = {
       ...this._config,
@@ -20219,6 +20561,18 @@ Tip: Check your Home Assistant media folder in Settings > System > Storage`;
                   @change=${this._actionButtonsHideOnThisDayButtonChanged}
                 />
                 <div class="help-text">Hide the Through the Years action button; the feature remains accessible via the clock/date overlay</div>
+              </div>
+            </div>
+
+            <div class="config-row">
+              <label>Cast to TV Button</label>
+              <div>
+                <input
+                  type="checkbox"
+                  .checked=${this._config.show_cast_button === true}
+                  @change=${this._showCastButtonChanged}
+                />
+                <div class="help-text">Show a cast icon to mirror this card to any media_player entity (LG, Chromecast, etc.) in real time (requires media_index)</div>
               </div>
             </div>
           </div>

--- a/ha-media-card.js
+++ b/ha-media-card.js
@@ -4092,6 +4092,19 @@ class SequentialMediaIndexProvider extends MediaProvider {
       let allFilteredItems = [];
       let seenPaths = new Set(); // Track paths we've already added to avoid duplicates
       let iteration = 0;
+
+      // Resolve date range filters from config (supports static dates or HA entity IDs)
+      const _resolveDateFilter = (configValue) => {
+        if (!configValue) return null;
+        if (typeof configValue === 'string' && configValue.includes('.')) {
+          // Entity ID — look up current state
+          const state = this.hass?.states[configValue];
+          return state?.state?.split(' ')[0] || null;
+        }
+        return configValue;
+      };
+      const dateFrom = _resolveDateFilter(this.config.filters?.date_range?.start);
+      const dateTo = _resolveDateFilter(this.config.filters?.date_range?.end);
       // Track consecutive batches where ALL items were excluded - used as a safety escape valve.
       // Resets to 0 whenever a batch yields at least one valid item, so a single large excluded
       // folder won't halt iteration; only a pathological config (everything excluded) will stop it.
@@ -4118,7 +4131,9 @@ class SequentialMediaIndexProvider extends MediaProvider {
           // V5 FEATURE: Priority new files - prepend recently indexed files to results
           // Note: Recently indexed = newly discovered by scanner, not necessarily new files
           priority_new_files: this.config.folder?.priority_new_files || false,
-          new_files_threshold_seconds: this.config.folder?.new_files_threshold_seconds || 3600
+          new_files_threshold_seconds: this.config.folder?.new_files_threshold_seconds || 3600,
+          ...(dateFrom ? { date_from: dateFrom } : {}),
+          ...(dateTo ? { date_to: dateTo } : {}),
         };
         
         // Add compound cursor for pagination (if we've seen items before)

--- a/ha-media-card.js
+++ b/ha-media-card.js
@@ -75,7 +75,7 @@ const MediaUtils = {
     
     if (['mp4', 'webm', 'ogg', 'mov', 'm4v'].includes(extension)) {
       return 'video';
-    } else if (['jpg', 'jpeg', 'png', 'gif', 'webp', 'svg', 'bmp', 'heic'].includes(extension)) {
+    } else if (['jpg', 'jpeg', 'png', 'gif', 'webp', 'svg', 'bmp', 'heic', 'heif'].includes(extension)) {
       return 'image';
     }
     
@@ -4956,6 +4956,9 @@ class MediaCard extends LitElement {
     this._livePhotoCompanionVideoCache = new Map();
     this._livePhotoGeneration = 0;
 
+    this._heicObjectUrlCache = new Map();
+    this._heicConverterPromise = null;
+
     this._log('💎 Constructor called, cardId:', this._cardId);
   }
 
@@ -5109,6 +5112,7 @@ class MediaCard extends LitElement {
     
     // Cleanup Live Photo playback timers
     this._clearLivePhotoPlayback();
+    this._revokeHeicObjectUrls();
   }
 
   // V4: Force video reload when URL changes
@@ -5592,6 +5596,13 @@ class MediaCard extends LitElement {
         still_extensions: ['JPG', 'jpg', 'JPEG', 'jpeg', 'PNG', 'png', 'WEBP', 'webp'],
         hide_companion_videos: true,
         ...config.live_photo
+      },
+      heic: {
+        enabled: true,
+        library_url: 'https://cdn.jsdelivr.net/npm/heic2any@0.0.4/dist/heic2any.min.js',
+        output_type: 'image/jpeg',
+        quality: 0.92,
+        ...config.heic
       },
       // V5.6: Clock/Date Overlay defaults
       clock: {
@@ -7584,6 +7595,108 @@ class MediaCard extends LitElement {
     return null; // Provider doesn't support file existence checks
   }
 
+  _isHeicMedia(pathOrItem = this.currentMedia) {
+    const path = typeof pathOrItem === 'string'
+      ? pathOrItem
+      : (
+          pathOrItem?.media_content_id ||
+          pathOrItem?.media_source_uri ||
+          pathOrItem?.path ||
+          pathOrItem?.title ||
+          ''
+        );
+    const cleanPath = (path || '').split('?')[0].split('|')[0].toLowerCase();
+    return cleanPath.endsWith('.heic') || cleanPath.endsWith('.heif');
+  }
+
+  _revokeHeicObjectUrls() {
+    if (!this._heicObjectUrlCache) return;
+
+    for (const objectUrl of this._heicObjectUrlCache.values()) {
+      URL.revokeObjectURL(objectUrl);
+    }
+
+    this._heicObjectUrlCache.clear();
+  }
+
+  _loadHeicConverter() {
+    if (window.heic2any) {
+      return Promise.resolve(window.heic2any);
+    }
+
+    if (this._heicConverterPromise) {
+      return this._heicConverterPromise;
+    }
+
+    const libraryUrl = this.config?.heic?.library_url ||
+      'https://cdn.jsdelivr.net/npm/heic2any@0.0.4/dist/heic2any.min.js';
+
+    this._heicConverterPromise = new Promise((resolve, reject) => {
+      const existingScript = document.querySelector(`script[data-ha-media-heic2any="${libraryUrl}"]`);
+      if (existingScript) {
+        existingScript.addEventListener('load', () => resolve(window.heic2any), { once: true });
+        existingScript.addEventListener('error', reject, { once: true });
+        return;
+      }
+
+      const script = document.createElement('script');
+      script.src = libraryUrl;
+      script.async = true;
+      script.dataset.haMediaHeic2any = libraryUrl;
+      script.onload = () => {
+        if (window.heic2any) {
+          resolve(window.heic2any);
+        } else {
+          reject(new Error('heic2any loaded without exposing window.heic2any'));
+        }
+      };
+      script.onerror = () => reject(new Error(`Failed to load HEIC converter: ${libraryUrl}`));
+      document.head.appendChild(script);
+    });
+
+    return this._heicConverterPromise;
+  }
+
+  async _prepareHeicDisplayUrl(url, expectedNavigationIndex) {
+    if (this.config?.heic?.enabled === false || (!this._isHeicMedia(this.currentMedia) && !this._isHeicMedia(url))) {
+      return url;
+    }
+
+    if (this._heicObjectUrlCache?.has(url)) {
+      return this._heicObjectUrlCache.get(url);
+    }
+
+    try {
+      this._log('🖼️ Converting HEIC image for browser display:', this.currentMedia?.media_content_id || url);
+      const converter = await this._loadHeicConverter();
+      const response = await fetch(url, { credentials: 'same-origin' });
+      if (!response.ok) {
+        throw new Error(`HEIC fetch failed with ${response.status}`);
+      }
+
+      const inputBlob = await response.blob();
+      const outputBlob = await converter({
+        blob: inputBlob,
+        toType: this.config?.heic?.output_type || 'image/jpeg',
+        quality: Number(this.config?.heic?.quality) || 0.92
+      });
+      const finalBlob = Array.isArray(outputBlob) ? outputBlob[0] : outputBlob;
+      const objectUrl = URL.createObjectURL(finalBlob);
+
+      const currentNavIndex = this._pendingNavigationIndex ?? this.navigationIndex;
+      if (expectedNavigationIndex !== undefined && currentNavIndex !== expectedNavigationIndex) {
+        URL.revokeObjectURL(objectUrl);
+        return '';
+      }
+
+      this._heicObjectUrlCache.set(url, objectUrl);
+      return objectUrl;
+    } catch (error) {
+      console.warn('[MediaCard] HEIC conversion failed, falling back to native image support:', error);
+      return url;
+    }
+  }
+
   // V5.6: Helper to set mediaUrl with crossfade transition (validates first for images)
   async _setMediaUrl(url, expectedNavigationIndex) {
     // V5.6.7: Guard against stale async resolutions during rapid navigation
@@ -7617,6 +7730,7 @@ class MediaCard extends LitElement {
     // layers get cleared, _renderMedia renders nothing, _onMediaLoaded never fires, and
     // _navigatingAway stays true — freezing the slideshow timer permanently.
     const isVideo = this._isVideoFile(url) || this._isCurrentItemVideo(url);
+    let displayUrl = url;
     
     // For images, validate they exist before displaying (MediaIndexProvider only)
     if (!isVideo) {
@@ -7636,9 +7750,14 @@ class MediaCard extends LitElement {
       }
       // If providerCheckResult is null, provider doesn't support checks (FolderProvider, SingleMediaProvider)
       // These providers discover files from disk, so 404s are unlikely - proceed without validation
+
+      displayUrl = await this._prepareHeicDisplayUrl(url, expectedNavigationIndex);
+      if (!displayUrl) {
+        return;
+      }
     }
     
-    this.mediaUrl = url;
+    this.mediaUrl = displayUrl;
     
     if (!isVideo) {
       const duration = this.config?.transition?.duration ?? 300;
@@ -7661,7 +7780,7 @@ class MediaCard extends LitElement {
         // This handles rapid navigation where the previous image hasn't loaded yet
         if (!this._frontLayerUrl && !this._backLayerUrl) {
           // Special case: Both layers empty (first load or after video), show immediately without crossfade
-          this._frontLayerUrl = url;
+          this._frontLayerUrl = displayUrl;
           this._frontLayerActive = true;
           this._pendingLayerSwap = false;
           this._frontLayerNavigationIndex = expectedNavigationIndex;
@@ -7669,7 +7788,7 @@ class MediaCard extends LitElement {
         } else if (this._pendingLayerSwap) {
           // Rapid navigation: Previous image hasn't loaded yet. Clear both and start fresh.
           this._log(`⏩ Rapid navigation detected - clearing both layers`);
-          this._frontLayerUrl = url;
+          this._frontLayerUrl = displayUrl;
           this._frontLayerGeneration++; // Invalidate any pending setTimeout for front layer
           this._backLayerUrl = '';
           this._backLayerGeneration++; // Invalidate any pending setTimeout for back layer
@@ -7681,11 +7800,11 @@ class MediaCard extends LitElement {
         } else {
           // Normal crossfade: load on hidden layer then swap
           if (this._frontLayerActive) {
-            this._backLayerUrl = url;
+            this._backLayerUrl = displayUrl;
             this._backLayerGeneration++; // Increment to invalidate any pending setTimeout for this layer
             this._backLayerNavigationIndex = expectedNavigationIndex;
           } else {
-            this._frontLayerUrl = url;
+            this._frontLayerUrl = displayUrl;
             this._frontLayerGeneration++; // Increment to invalidate any pending setTimeout for this layer
             this._frontLayerNavigationIndex = expectedNavigationIndex;
           }
@@ -21282,6 +21401,5 @@ console.info(
   'color: lime; font-weight: bold; background: black',
   'color: white; font-weight: bold; background: green'
 );
-
 
 })();

--- a/ha-media-card.js
+++ b/ha-media-card.js
@@ -4791,6 +4791,7 @@ class MediaCard extends LitElement {
         pause_duration: 10,
         video_suffixes: ['_HEVC', '-HEVC', ''],
         video_extensions: ['MOV', 'mov', 'mp4', 'MP4', 'm4v', 'M4V'],
+        still_extensions: ['JPG', 'jpg', 'JPEG', 'jpeg', 'PNG', 'png', 'WEBP', 'webp'],
         hide_companion_videos: true,
         ...config.live_photo
       }
@@ -4952,6 +4953,7 @@ class MediaCard extends LitElement {
     this._livePhotoVideoReady = false;
     this._livePhotoTimer = null;
     this._livePhotoCompanionCache = new Map();
+    this._livePhotoCompanionVideoCache = new Map();
     this._livePhotoGeneration = 0;
 
     this._log('💎 Constructor called, cardId:', this._cardId);
@@ -5587,6 +5589,7 @@ class MediaCard extends LitElement {
         pause_duration: 10,
         video_suffixes: ['_HEVC', '-HEVC', ''],
         video_extensions: ['MOV', 'mov', 'mp4', 'MP4', 'm4v', 'M4V'],
+        still_extensions: ['JPG', 'jpg', 'JPEG', 'jpeg', 'PNG', 'png', 'WEBP', 'webp'],
         hide_companion_videos: true,
         ...config.live_photo
       },
@@ -6225,7 +6228,7 @@ class MediaCard extends LitElement {
           const _syncGenBefore = this._syncNavGeneration || 0;
           let item = await this.provider.getNext();
           let hiddenCompanionAttempts = 0;
-          while (item && this._shouldHideLivePhotoCompanionVideo(item) && hiddenCompanionAttempts < 25) {
+          while (item && await this._shouldHideLivePhotoCompanionVideo(item) && hiddenCompanionAttempts < 25) {
             this._log('🎞️ Skipping Live Photo companion video in slideshow queue:', item.media_content_id);
             item = await this.provider.getNext();
             hiddenCompanionAttempts++;
@@ -6243,7 +6246,7 @@ class MediaCard extends LitElement {
               this._log(`⚠️ Item already in navigation queue (attempt ${attempts + 1}), getting next:`, item.media_content_id);
               item = await this.provider.getNext();
               hiddenCompanionAttempts = 0;
-              while (item && this._shouldHideLivePhotoCompanionVideo(item) && hiddenCompanionAttempts < 25) {
+              while (item && await this._shouldHideLivePhotoCompanionVideo(item) && hiddenCompanionAttempts < 25) {
                 this._log('🎞️ Skipping Live Photo companion video in slideshow queue:', item.media_content_id);
                 item = await this.provider.getNext();
                 hiddenCompanionAttempts++;
@@ -6349,7 +6352,7 @@ class MediaCard extends LitElement {
         return;
       }
       
-      if (this._shouldHideLivePhotoCompanionVideo(item)) {
+      if (await this._shouldHideLivePhotoCompanionVideo(item)) {
         this._log('🎞️ Removing Live Photo companion video from navigation queue:', item.media_content_id);
         this._removeItemFromQueues(item);
         this._isLoadingNext = false;
@@ -8277,7 +8280,71 @@ class MediaCard extends LitElement {
            MediaUtils.detectFileType(item.title || '') === 'image';
   }
 
-  _shouldHideLivePhotoCompanionVideo(item) {
+  _buildLivePhotoStillCandidatesForVideo(item) {
+    const mediaId = this._getLivePhotoItemId(item);
+    if (!mediaId) return [];
+
+    const cleanId = mediaId.split('?')[0];
+    const slashIndex = cleanId.lastIndexOf('/');
+    const dotIndex = cleanId.lastIndexOf('.');
+    if (dotIndex <= slashIndex) return [];
+
+    const basePath = cleanId.substring(0, dotIndex);
+    const basePaths = new Set([basePath]);
+    const suffixes = this.config?.live_photo?.video_suffixes || ['_HEVC', '-HEVC', ''];
+    for (const suffix of suffixes) {
+      if (suffix && basePath.toLowerCase().endsWith(String(suffix).toLowerCase())) {
+        basePaths.add(basePath.substring(0, basePath.length - String(suffix).length));
+      }
+    }
+
+    const stillExtensions = this.config?.live_photo?.still_extensions ||
+      ['JPG', 'jpg', 'JPEG', 'jpeg', 'PNG', 'png', 'WEBP', 'webp'];
+    const candidates = [];
+    const seen = new Set();
+    for (const stillBasePath of basePaths) {
+      for (const extension of stillExtensions) {
+        const candidate = `${stillBasePath}.${extension}`;
+        if (!seen.has(candidate)) {
+          candidates.push(candidate);
+          seen.add(candidate);
+        }
+      }
+    }
+    return candidates;
+  }
+
+  async _hasLivePhotoStillForVideo(item) {
+    const itemId = this._getLivePhotoItemId(item);
+    if (!itemId || !this.hass) return false;
+
+    if (this._livePhotoCompanionVideoCache.has(itemId)) {
+      return this._livePhotoCompanionVideoCache.get(itemId);
+    }
+
+    for (const candidate of this._buildLivePhotoStillCandidatesForVideo(item)) {
+      const mediaContentId = candidate.startsWith('/media/')
+        ? `media-source://media_source${candidate}`
+        : candidate;
+      try {
+        await this.hass.callWS({
+          type: 'media_source/resolve_media',
+          media_content_id: mediaContentId,
+          expires: 60
+        });
+        this._livePhotoCompanionVideoCache.set(itemId, true);
+        this._log('🎞️ Live Photo still found for companion video:', mediaContentId);
+        return true;
+      } catch (error) {
+        // Candidate does not exist or is not resolvable; try the next still extension.
+      }
+    }
+
+    this._livePhotoCompanionVideoCache.set(itemId, false);
+    return false;
+  }
+
+  async _shouldHideLivePhotoCompanionVideo(item) {
     if (!this._isLivePhotoEnabled() || this.config?.live_photo?.hide_companion_videos === false) {
       return false;
     }
@@ -8285,9 +8352,10 @@ class MediaCard extends LitElement {
 
     const baseName = this._getLivePhotoBaseName(item).toLowerCase();
     const suffixes = this.config?.live_photo?.video_suffixes || ['_HEVC', '-HEVC'];
-    return suffixes
+    const hasCompanionSuffix = suffixes
       .filter(suffix => suffix && String(suffix).length > 0)
       .some(suffix => baseName.endsWith(String(suffix).toLowerCase()));
+    return hasCompanionSuffix || await this._hasLivePhotoStillForVideo(item);
   }
 
   _removeItemFromQueues(item) {

--- a/ha-media-card.js
+++ b/ha-media-card.js
@@ -20649,7 +20649,7 @@ Tip: Check your Home Assistant media folder in Settings > System > Storage`;
                   .checked=${this._config.show_cast_button === true}
                   @change=${this._showCastButtonChanged}
                 />
-                <div class="help-text">Show a cast icon to mirror this card to any media_player entity (LG, Chromecast, etc.) in real time (requires media_index)</div>
+                <div class="help-text">Show a cast icon to mirror this card to any media_player entity in real time. Roku uses media_index.roku_ecp_cast (requires media_index). Other players (LG, Chromecast, etc.) use media_player.play_media directly.</div>
               </div>
             </div>
           </div>

--- a/ha-media-card.js
+++ b/ha-media-card.js
@@ -20191,6 +20191,44 @@ Tip: Check your Home Assistant media folder in Settings > System > Storage`;
       color: var(--primary-text-color);
     }
 
+    .integration-callout {
+      background: var(--primary-background-color, #fafafa);
+      padding: 16px;
+      border-radius: 8px;
+      margin-bottom: 20px;
+      border: 1px solid var(--divider-color, #e0e0e0);
+    }
+
+    .integration-callout-title {
+      margin-bottom: 12px;
+      font-weight: 600;
+      color: var(--primary-text-color);
+    }
+
+    .integration-callout p {
+      margin: 4px 0 12px 0;
+      font-size: 13px;
+      color: var(--secondary-text-color, #666);
+      line-height: 1.45;
+    }
+
+    .integration-callout a {
+      color: var(--primary-color, #007bff);
+      text-decoration: none;
+      font-weight: 500;
+    }
+
+    .integration-callout a:hover {
+      text-decoration: underline;
+    }
+
+    .integration-callout code {
+      background: var(--code-background-color, rgba(0,0,0,0.1));
+      padding: 1px 4px;
+      border-radius: 3px;
+      font-size: 12px;
+    }
+
     .support-footer {
       margin-top: 24px;
       padding: 16px;
@@ -20307,6 +20345,24 @@ Tip: Check your Home Assistant media folder in Settings > System > Storage`;
             </div>
           ` : ''}
         </div>
+
+        ${isFolderMode ? html`
+          <div class="integration-callout">
+            <div class="integration-callout-title">iCloud Photos Sync</div>
+            <p>
+              To display iCloud Photos here, install the
+              <a href="https://github.com/anciltech/ha-icloud-photo-sync" target="_blank" rel="noopener noreferrer">AncilTech iCloud Photo Sync add-on</a>
+              from the Home Assistant Add-on Store repositories. The add-on downloads selected albums into
+              <code>/media/icloud_photos</code>; this card handles display.
+            </p>
+            <p>
+              After the add-on syncs, use
+              <code>media-source://media_source/local/icloud_photos</code>
+              as the folder path, or append an album folder such as
+              <code>/Favorites</code>.
+            </p>
+          </div>
+        ` : ''}
 
         <!-- Filters Section (available when Media Index is enabled) -->
         ${hasMediaIndex && isFolderMode && folderConfig.use_media_index_for_discovery !== false ? html`

--- a/ha-media-card.js
+++ b/ha-media-card.js
@@ -4954,6 +4954,7 @@ class MediaCard extends LitElement {
     this._livePhotoTimer = null;
     this._livePhotoCompanionCache = new Map();
     this._livePhotoCompanionVideoCache = new Map();
+    this._livePhotoNegativeCacheMs = 5 * 60 * 1000;
     this._livePhotoGeneration = 0;
 
     this._heicObjectUrlCache = new Map();
@@ -5497,6 +5498,8 @@ class MediaCard extends LitElement {
       this._refreshInterval = null;
     }
     this._clearLivePhotoPlayback();
+    this._livePhotoCompanionCache?.clear();
+    this._livePhotoCompanionVideoCache?.clear();
     
     // V5: Validate and clamp max_height_pixels if present
     if (config.max_height_pixels !== undefined) {
@@ -5914,6 +5917,7 @@ class MediaCard extends LitElement {
           // Queue and index already set — jump directly to the saved item
           const item = this.navigationQueue[this.navigationIndex];
           if (item) {
+            this._clearLivePhotoPlayback();
             this.currentMedia = item;
             this._pendingNavigationIndex = this.navigationIndex;
             this._pendingMediaPath = item.media_content_id;
@@ -5927,6 +5931,7 @@ class MediaCard extends LitElement {
           this._log('🔄 Reconnected with history - loading media at position', this.historyPosition);
           const historyItem = this.history[this.historyPosition];
           if (historyItem) {
+            this._clearLivePhotoPlayback();
             this.currentMedia = historyItem;
             await this._resolveMediaUrl();
           } else {
@@ -6566,6 +6571,7 @@ class MediaCard extends LitElement {
     }
     
     // Display the item
+    this._clearLivePhotoPlayback();
     this.currentMedia = item;
     
     // V5.6.7: Store in pending state - will apply when image/video loads (syncs all overlays)
@@ -6700,6 +6706,7 @@ class MediaCard extends LitElement {
     
     // Update current media - THIS IS CRITICAL for main image display
     const mediaUri = item.media_source_uri || item.path;
+    this._clearLivePhotoPlayback();
     this.currentMedia = {
       media_content_id: mediaUri,
       media_content_type: item.filename?.toLowerCase().endsWith('.mp4') ? 'video' : 'image',
@@ -6755,6 +6762,7 @@ class MediaCard extends LitElement {
 
     // Load the item from the queue
     const item = this.navigationQueue[queueIndex];
+    this._clearLivePhotoPlayback();
     this.currentMedia = item;
     
     // V5.6.7: Store in pending state - will apply when image/video loads  
@@ -7154,6 +7162,7 @@ class MediaCard extends LitElement {
     }
     
     // Display the media (same pattern as _loadNext)
+    this._clearLivePhotoPlayback();
     this.currentMedia = currentItem;
     this._pendingMediaPath = currentItem.media_content_id;
     this._pendingMetadata = currentItem.metadata || null;
@@ -7465,6 +7474,7 @@ class MediaCard extends LitElement {
         // Check if we should display this new first item
         const shouldUpdate = !currentMediaId || firstItem.media_content_id !== currentMediaId;
         
+        this._clearLivePhotoPlayback();
         this.currentMedia = firstItem;
         
         // CRITICAL: Update _currentMetadata and _currentMediaPath for overlay display
@@ -8639,13 +8649,22 @@ class MediaCard extends LitElement {
     const itemId = this._getLivePhotoItemId(item);
     if (!itemId || !this.hass) return false;
 
-    if (this._livePhotoCompanionVideoCache.has(itemId)) {
-      return this._livePhotoCompanionVideoCache.get(itemId) === true;
+    const cached = this._livePhotoCompanionVideoCache.get(itemId);
+    if (cached === true) {
+      return true;
+    }
+    if (cached && cached.value === false) {
+      if (Date.now() - cached.checkedAt < this._livePhotoNegativeCacheMs) {
+        return false;
+      }
+      this._livePhotoCompanionVideoCache.delete(itemId);
+    } else if (cached === false) {
+      return false;
     }
 
     const candidates = this._buildLivePhotoStillCandidatesForVideo(item);
     if (!candidates.length) {
-      this._livePhotoCompanionVideoCache.set(itemId, false);
+      this._livePhotoCompanionVideoCache.set(itemId, { value: false, checkedAt: Date.now() });
       return false;
     }
 
@@ -8667,7 +8686,7 @@ class MediaCard extends LitElement {
       }
     }
 
-    this._livePhotoCompanionVideoCache.set(itemId, false);
+    this._livePhotoCompanionVideoCache.set(itemId, { value: false, checkedAt: Date.now() });
     return false;
   }
 
@@ -9610,6 +9629,7 @@ class MediaCard extends LitElement {
     this._log(`🔗 Shared queue synced on reconnect: ${this.navigationQueue.length} items, index ${newIndex}`);
     if (newPath !== this._currentMediaPath) {
       const item = this.navigationQueue[newIndex];
+      this._clearLivePhotoPlayback();
       this.currentMedia = item;
       this._pendingNavigationIndex = newIndex;
       this._pendingMediaPath = newPath;
@@ -9995,6 +10015,7 @@ class MediaCard extends LitElement {
     }));
     this.navigationIndex = newIndex;
     const item = this.navigationQueue[newIndex];
+    this._clearLivePhotoPlayback();
     this.currentMedia = item;
     this._pendingNavigationIndex = newIndex;
     this._pendingMediaPath = newPath;
@@ -13358,6 +13379,7 @@ class MediaCard extends LitElement {
         const restoredItem = this.navigationQueue[this.navigationIndex];
         if (restoredItem) {
           // Properly restore display state (same as _loadNext)
+          this._clearLivePhotoPlayback();
           this.currentMedia = restoredItem;
           this._currentMediaPath = restoredItem.media_content_id;
           this._currentMetadata = restoredItem.metadata || null;

--- a/ha-media-card.js
+++ b/ha-media-card.js
@@ -4894,6 +4894,8 @@ class MediaCard extends LitElement {
     this._manualNavLoading = false;    // True from navigation commit until _onMediaLoaded/_onVideoCanPlay fires
     this._swipeTouchStartX = null;    // Touch start X for swipe gesture detection
     this._swipeTouchStartY = null;    // Touch start Y for swipe gesture detection
+    this._navigationGeneration = 0;    // Increments whenever newer navigation should obsolete async work
+    this._activeMediaPrepare = null;   // Current off-DOM image/video preparation task
     
     // V5.6.0: Play randomized option for panels
     this._playRandomized = false;      // Toggle for randomizing panel playback order
@@ -5112,6 +5114,7 @@ class MediaCard extends LitElement {
     
     // Cleanup Live Photo playback timers
     this._clearLivePhotoPlayback();
+    this._cancelActiveMediaPrepare('card disconnect');
     this._revokeHeicObjectUrls();
   }
 
@@ -5603,6 +5606,13 @@ class MediaCard extends LitElement {
         output_type: 'image/jpeg',
         quality: 0.92,
         ...config.heic
+      },
+      preload: {
+        enabled: true,
+        image_decode: true,
+        video_mode: 'metadata',
+        video_timeout_ms: 3000,
+        ...config.preload
       },
       // V5.6: Clock/Date Overlay defaults
       clock: {
@@ -6135,9 +6145,16 @@ class MediaCard extends LitElement {
   async _loadNext() {
     // V5.6.7: Re-entrance guard - prevent concurrent calls to _loadNext
     if (this._isLoadingNext) {
-      this._log('⏭️ Skipping _loadNext - already in progress');
-      return;
+      if (!this._isManualNavigation) {
+        this._log('⏭️ Skipping _loadNext - already in progress');
+        return;
+      }
+      this._log('⏭️ Manual next requested while load is in progress - canceling stale preparation');
+      this._cancelActiveMediaPrepare('manual next');
+      this._isLoadingNext = false;
     }
+    this._navigationGeneration++;
+    const navigationGeneration = this._navigationGeneration;
     this._isLoadingNext = true;
 
     try {
@@ -6243,6 +6260,11 @@ class MediaCard extends LitElement {
             this._log('🎞️ Skipping Live Photo companion video in slideshow queue:', item.media_content_id);
             item = await this.provider.getNext();
             hiddenCompanionAttempts++;
+          }
+
+          if (navigationGeneration !== this._navigationGeneration) {
+            this._log('⏭️ Discarding stale next-item provider result after newer navigation');
+            return;
           }
         
           if (item) {
@@ -6371,6 +6393,11 @@ class MediaCard extends LitElement {
         return;
       }
 
+      if (navigationGeneration !== this._navigationGeneration) {
+        this._log('⏭️ Discarding stale next navigation before display');
+        return;
+      }
+
       // V5.6.8: Increment periodic refresh counter and check if refresh needed
       // Works for both sequential and random modes - provider handles mode-specific logic
       this._itemsSinceRefresh++;
@@ -6464,9 +6491,16 @@ class MediaCard extends LitElement {
   async _loadPrevious() {
     // V5.6.7: Re-entrance guard - prevent concurrent calls to _loadPrevious
     if (this._isLoadingNext) {
-      this._log('⏮️ Skipping _loadPrevious - already in progress');
-      return;
+      if (!this._isManualNavigation) {
+        this._log('⏮️ Skipping _loadPrevious - already in progress');
+        return;
+      }
+      this._log('⏮️ Manual previous requested while load is in progress - canceling stale preparation');
+      this._cancelActiveMediaPrepare('manual previous');
+      this._isLoadingNext = false;
     }
+    this._navigationGeneration++;
+    const navigationGeneration = this._navigationGeneration;
     this._isLoadingNext = true;
 
     try {
@@ -6527,6 +6561,11 @@ class MediaCard extends LitElement {
     }
     
     this._log('Going back to navigation queue item:', item.title, 'at index', this.navigationIndex);
+
+    if (navigationGeneration !== this._navigationGeneration) {
+      this._log('⏮️ Discarding stale previous navigation before display');
+      return;
+    }
     
     // Display the item
     this.currentMedia = item;
@@ -6634,6 +6673,8 @@ class MediaCard extends LitElement {
 
   async _loadPanelItem(index) {
     // V5.6: Set flag to ignore video pause events during thumbnail click
+    this._navigationGeneration++;
+    this._cancelActiveMediaPrepare('panel navigation');
     this._navigatingAway = true;
     
     const item = this._panelQueue[index];
@@ -6694,6 +6735,8 @@ class MediaCard extends LitElement {
 
   async _jumpToQueuePosition(queueIndex) {
     // V5.6: Set flag to ignore video pause events during thumbnail click
+    this._navigationGeneration++;
+    this._cancelActiveMediaPrepare('queue jump');
     this._navigatingAway = true;
     
     if (!this.navigationQueue || queueIndex < 0 || queueIndex >= this.navigationQueue.length) {
@@ -7609,6 +7652,39 @@ class MediaCard extends LitElement {
     return cleanPath.endsWith('.heic') || cleanPath.endsWith('.heif');
   }
 
+  _isNavigationCurrent(expectedNavigationIndex, expectedGeneration) {
+    if (expectedGeneration !== undefined && expectedGeneration !== this._navigationGeneration) {
+      return false;
+    }
+    if (expectedNavigationIndex !== undefined && this._pendingNavigationIndex !== expectedNavigationIndex) {
+      return false;
+    }
+    return true;
+  }
+
+  _cancelActiveMediaPrepare(reason = 'navigation') {
+    const active = this._activeMediaPrepare;
+    if (!active) return;
+
+    active.cancelled = true;
+    active.abortController?.abort?.();
+    if (active.element) {
+      try {
+        if (active.type === 'video') {
+          active.element.pause?.();
+          active.element.removeAttribute('src');
+          active.element.load?.();
+        } else {
+          active.element.src = '';
+        }
+      } catch (error) {
+        // Best-effort cleanup only; stale generation checks still protect the UI.
+      }
+    }
+    this._activeMediaPrepare = null;
+    this._log(`⏭️ Canceled media preparation (${reason})`);
+  }
+
   _revokeHeicObjectUrls() {
     if (!this._heicObjectUrlCache) return;
 
@@ -7657,7 +7733,7 @@ class MediaCard extends LitElement {
     return this._heicConverterPromise;
   }
 
-  async _prepareHeicDisplayUrl(url, expectedNavigationIndex) {
+  async _prepareHeicDisplayUrl(url, expectedNavigationIndex, expectedGeneration) {
     if (this.config?.heic?.enabled === false || (!this._isHeicMedia(this.currentMedia) && !this._isHeicMedia(url))) {
       return url;
     }
@@ -7669,10 +7745,13 @@ class MediaCard extends LitElement {
     try {
       this._log('🖼️ Converting HEIC image for browser display:', this.currentMedia?.media_content_id || url);
       const converter = await this._loadHeicConverter();
+      if (!this._isNavigationCurrent(expectedNavigationIndex, expectedGeneration)) return '';
+
       const response = await fetch(url, { credentials: 'same-origin' });
       if (!response.ok) {
         throw new Error(`HEIC fetch failed with ${response.status}`);
       }
+      if (!this._isNavigationCurrent(expectedNavigationIndex, expectedGeneration)) return '';
 
       const inputBlob = await response.blob();
       const outputBlob = await converter({
@@ -7683,8 +7762,7 @@ class MediaCard extends LitElement {
       const finalBlob = Array.isArray(outputBlob) ? outputBlob[0] : outputBlob;
       const objectUrl = URL.createObjectURL(finalBlob);
 
-      const currentNavIndex = this._pendingNavigationIndex ?? this.navigationIndex;
-      if (expectedNavigationIndex !== undefined && currentNavIndex !== expectedNavigationIndex) {
+      if (!this._isNavigationCurrent(expectedNavigationIndex, expectedGeneration)) {
         URL.revokeObjectURL(objectUrl);
         return '';
       }
@@ -7697,11 +7775,137 @@ class MediaCard extends LitElement {
     }
   }
 
+  async _prepareMediaForDisplay(url, isVideo, expectedNavigationIndex, expectedGeneration) {
+    if (!url || this.config?.preload?.enabled === false) return true;
+    if (!this._isNavigationCurrent(expectedNavigationIndex, expectedGeneration)) return false;
+    this._cancelActiveMediaPrepare('new media prepare');
+
+    if (isVideo) {
+      return this._preloadVideoForDisplay(url, expectedNavigationIndex, expectedGeneration);
+    }
+
+    return this._preloadImageForDisplay(url, expectedNavigationIndex, expectedGeneration);
+  }
+
+  async _preloadImageForDisplay(url, expectedNavigationIndex, expectedGeneration) {
+    const image = new Image();
+    const abortController = new AbortController();
+    const active = { type: 'image', element: image, abortController, generation: expectedGeneration, cancelled: false };
+    this._activeMediaPrepare = active;
+
+    try {
+      await new Promise((resolve, reject) => {
+        const cleanup = () => {
+          image.onload = null;
+          image.onerror = null;
+          abortController.signal.removeEventListener('abort', onAbort);
+        };
+        const onAbort = () => {
+          cleanup();
+          reject(new DOMException('Image preload aborted', 'AbortError'));
+        };
+        image.onload = () => {
+          cleanup();
+          resolve();
+        };
+        image.onerror = () => {
+          cleanup();
+          reject(new Error('Image preload failed'));
+        };
+        abortController.signal.addEventListener('abort', onAbort, { once: true });
+        image.decoding = 'async';
+        image.loading = 'eager';
+        image.src = url;
+      });
+
+      if (this.config?.preload?.image_decode !== false && typeof image.decode === 'function') {
+        await image.decode().catch(() => {});
+      }
+
+      return this._isNavigationCurrent(expectedNavigationIndex, expectedGeneration);
+    } catch (error) {
+      if (error?.name === 'AbortError' || !this._isNavigationCurrent(expectedNavigationIndex, expectedGeneration)) {
+        return false;
+      }
+      this._log('⚠️ Image preload failed; falling back to normal image load:', error.message || error);
+      return true;
+    } finally {
+      if (this._activeMediaPrepare === active) {
+        this._activeMediaPrepare = null;
+      }
+    }
+  }
+
+  async _preloadVideoForDisplay(url, expectedNavigationIndex, expectedGeneration) {
+    const mode = this.config?.preload?.video_mode || 'metadata';
+    if (mode === 'none') return true;
+
+    const video = document.createElement('video');
+    const abortController = new AbortController();
+    const active = { type: 'video', element: video, abortController, generation: expectedGeneration, cancelled: false };
+    const eventName = mode === 'canplay' ? 'canplay' : 'loadedmetadata';
+    const timeoutMs = Math.max(250, Number(this.config?.preload?.video_timeout_ms) || 3000);
+    this._activeMediaPrepare = active;
+
+    try {
+      await new Promise((resolve, reject) => {
+        let timeoutId = null;
+        const cleanup = () => {
+          clearTimeout(timeoutId);
+          video.onloadedmetadata = null;
+          video.oncanplay = null;
+          video.onerror = null;
+          abortController.signal.removeEventListener('abort', onAbort);
+        };
+        const onReady = () => {
+          cleanup();
+          resolve();
+        };
+        const onAbort = () => {
+          cleanup();
+          reject(new DOMException('Video preload aborted', 'AbortError'));
+        };
+        timeoutId = setTimeout(() => {
+          cleanup();
+          resolve();
+        }, timeoutMs);
+        video[eventName === 'canplay' ? 'oncanplay' : 'onloadedmetadata'] = onReady;
+        video.onerror = () => {
+          cleanup();
+          resolve();
+        };
+        abortController.signal.addEventListener('abort', onAbort, { once: true });
+        video.preload = mode === 'canplay' ? 'auto' : 'metadata';
+        video.muted = true;
+        video.playsInline = true;
+        video.src = url;
+        video.load();
+      });
+
+      return this._isNavigationCurrent(expectedNavigationIndex, expectedGeneration);
+    } catch (error) {
+      if (error?.name === 'AbortError' || !this._isNavigationCurrent(expectedNavigationIndex, expectedGeneration)) {
+        return false;
+      }
+      return true;
+    } finally {
+      if (this._activeMediaPrepare === active) {
+        this._activeMediaPrepare = null;
+      }
+      try {
+        video.removeAttribute('src');
+        video.load();
+      } catch (error) {
+        // Best-effort cleanup.
+      }
+    }
+  }
+
   // V5.6: Helper to set mediaUrl with crossfade transition (validates first for images)
-  async _setMediaUrl(url, expectedNavigationIndex) {
+  async _setMediaUrl(url, expectedNavigationIndex, expectedGeneration = this._navigationGeneration) {
     // V5.6.7: Guard against stale async resolutions during rapid navigation
     // If expectedNavigationIndex is provided and doesn't match current pending index, abort
-    if (expectedNavigationIndex !== undefined && this._pendingNavigationIndex !== expectedNavigationIndex) {
+    if (!this._isNavigationCurrent(expectedNavigationIndex, expectedGeneration)) {
       this._log(`⏭️ Skipping stale media resolution (expected: ${expectedNavigationIndex}, current: ${this._pendingNavigationIndex})`);
       // Clear the navigation-in-progress flag when nothing else has claimed a pending
       // path (i.e. no sync nav or newer _loadNext() is in flight). Without this,
@@ -7751,10 +7955,14 @@ class MediaCard extends LitElement {
       // If providerCheckResult is null, provider doesn't support checks (FolderProvider, SingleMediaProvider)
       // These providers discover files from disk, so 404s are unlikely - proceed without validation
 
-      displayUrl = await this._prepareHeicDisplayUrl(url, expectedNavigationIndex);
+      displayUrl = await this._prepareHeicDisplayUrl(url, expectedNavigationIndex, expectedGeneration);
       if (!displayUrl) {
         return;
       }
+    }
+
+    if (!await this._prepareMediaForDisplay(displayUrl, isVideo, expectedNavigationIndex, expectedGeneration)) {
+      return;
     }
     
     this.mediaUrl = displayUrl;
@@ -7876,6 +8084,7 @@ class MediaCard extends LitElement {
     
     // V5.6.7: Capture pending index for async resolution guard
     const expectedIndex = this._pendingNavigationIndex;
+    const expectedGeneration = this._navigationGeneration;
     
     // Validate mediaId exists
     if (!mediaId) {
@@ -7886,7 +8095,7 @@ class MediaCard extends LitElement {
     
     // If already a full URL, use it
     if (mediaId.startsWith('http')) {
-      await this._setMediaUrl(mediaId, expectedIndex);
+      await this._setMediaUrl(mediaId, expectedIndex, expectedGeneration);
       this.requestUpdate();
       return;
     }
@@ -7904,11 +8113,11 @@ class MediaCard extends LitElement {
         // Add timestamp for auto-refresh (camera snapshots, etc.)
         const finalUrl = this._addCacheBustingTimestamp(resolved.url);
         
-        await this._setMediaUrl(finalUrl, expectedIndex);
+        await this._setMediaUrl(finalUrl, expectedIndex, expectedGeneration);
         this.requestUpdate();
       } catch (error) {
         console.error('[MediaCard] Failed to resolve media URL:', error);
-        await this._setMediaUrl('', expectedIndex);
+        await this._setMediaUrl('', expectedIndex, expectedGeneration);
         this._nextMediaUrl = '';
         this.requestUpdate();
       }
@@ -7933,7 +8142,7 @@ class MediaCard extends LitElement {
         });
         this._log('✅ File exists and resolved to:', resolved.url);
         this._validationDepth = 0; // Reset on success
-        await this._setMediaUrl(resolved.url, expectedIndex);
+        await this._setMediaUrl(resolved.url, expectedIndex, expectedGeneration);
         this.requestUpdate();
         return; // Success - don't fall through to fallback
       } catch (error) {
@@ -7960,7 +8169,7 @@ class MediaCard extends LitElement {
         }
         
         // Clear the current media to avoid showing broken state
-        await this._setMediaUrl('', expectedIndex);
+        await this._setMediaUrl('', expectedIndex, expectedGeneration);
         
         // Check recursion depth before recursive call
         this._validationDepth = (this._validationDepth || 0) + 1;
@@ -7979,7 +8188,7 @@ class MediaCard extends LitElement {
 
     // Fallback: use as-is
     this._log('Using media ID as-is (fallback)');
-    await this._setMediaUrl(mediaId, expectedIndex);
+    await this._setMediaUrl(mediaId, expectedIndex, expectedGeneration);
     this.requestUpdate();
   }
 
@@ -8020,7 +8229,7 @@ class MediaCard extends LitElement {
   _onMediaError(e) {
     if (this._livePhotoPhase === 'video') {
       const itemId = this._getLivePhotoItemId(this.currentMedia);
-      if (itemId) this._livePhotoCompanionCache.set(itemId, null);
+      if (itemId) this._livePhotoCompanionCache.delete(itemId);
       this._livePhotoPhase = 'idle';
       this._livePhotoVideoUrl = '';
       this._log('🎞️ Live Photo companion video failed - keeping still image visible');
@@ -8437,8 +8646,8 @@ class MediaCard extends LitElement {
     const itemId = this._getLivePhotoItemId(item);
     if (!itemId || !this.hass) return false;
 
-    if (this._livePhotoCompanionVideoCache.has(itemId)) {
-      return this._livePhotoCompanionVideoCache.get(itemId);
+    if (this._livePhotoCompanionVideoCache.get(itemId) === true) {
+      return true;
     }
 
     for (const candidate of this._buildLivePhotoStillCandidatesForVideo(item)) {
@@ -8459,7 +8668,6 @@ class MediaCard extends LitElement {
       }
     }
 
-    this._livePhotoCompanionVideoCache.set(itemId, false);
     return false;
   }
 
@@ -8527,7 +8735,7 @@ class MediaCard extends LitElement {
     const itemId = this._getLivePhotoItemId(item);
     if (!itemId || !this.hass) return null;
 
-    if (this._livePhotoCompanionCache.has(itemId)) {
+    if (this._livePhotoCompanionCache.get(itemId)) {
       return this._livePhotoCompanionCache.get(itemId);
     }
 
@@ -8552,7 +8760,6 @@ class MediaCard extends LitElement {
       }
     }
 
-    this._livePhotoCompanionCache.set(itemId, null);
     return null;
   }
 
@@ -8626,7 +8833,7 @@ class MediaCard extends LitElement {
   _onLivePhotoVideoError() {
     if (this._livePhotoPhase !== 'video') return;
     const itemId = this._getLivePhotoItemId(this.currentMedia);
-    if (itemId) this._livePhotoCompanionCache.set(itemId, null);
+    if (itemId) this._livePhotoCompanionCache.delete(itemId);
     this._livePhotoPhase = 'still';
     this._livePhotoVideoUrl = '';
     this._livePhotoVideoReady = false;
@@ -9750,6 +9957,8 @@ class MediaCard extends LitElement {
     // competing _loadNext() while the sync-driven URL resolution is in flight.
     // _navigatingAway is cleared by _onMediaLoaded / _onVideoCanPlay as normal.
     this._navigatingAway = true;
+    this._navigationGeneration++;
+    this._cancelActiveMediaPrepare('shared queue navigation');
     this._resolveMediaUrl();
     this.requestUpdate();
     // For media-index cards: kick off a background fetch to get fresher/fuller

--- a/scripts/build-concat.mjs
+++ b/scripts/build-concat.mjs
@@ -1,0 +1,91 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const packageJson = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'));
+const version = packageJson.version;
+
+const sourceFiles = [
+  'src/core/media-utils.js',
+  'src/core/media-provider.js',
+  'src/core/media-index-helper.js',
+  'src/providers/single-media-provider.js',
+  'src/providers/folder-provider.js',
+  'src/providers/subfolder-queue.js',
+  'src/providers/media-index-provider.js',
+  'src/providers/sequential-media-index-provider.js',
+  'src/ui/media-card.js',
+  'src/editor/media-card-editor.js',
+  'src/main.js'
+];
+
+const litLoader = `// Async wrapper for dynamic Lit loading (supports offline mode)
+(async () => {
+  // Default CDN URL for Lit
+  const LIT_CDN_URL = 'https://cdn.jsdelivr.net/gh/lit/dist@3/core/lit-core.min.js';
+
+  let LitElement, html, css;
+
+  // Check if Lit was preloaded globally (for offline support)
+  if (window.LitElement && window.html && window.css) {
+    console.log('[Media Card] Using preloaded Lit from window');
+    LitElement = window.LitElement;
+    html = window.html;
+    css = window.css;
+  } else if (window.__LIT_PRELOAD_PROMISE__) {
+    // Preload script is loading Lit - wait for it
+    console.log('[Media Card] Waiting for Lit preload to complete...');
+    try {
+      await window.__LIT_PRELOAD_PROMISE__;
+      LitElement = window.LitElement;
+      html = window.html;
+      css = window.css;
+      console.log('[Media Card] Using preloaded Lit from window');
+    } catch (e) {
+      console.error('[Media Card] Lit preload failed:', e);
+      console.error('[Media Card] For offline use, check your preload script. See docs/OFFLINE_MODE.md');
+      return;
+    }
+  } else {
+    // Load Lit dynamically from CDN
+    try {
+      const litModule = await import(LIT_CDN_URL);
+      LitElement = litModule.LitElement;
+      html = litModule.html;
+      css = litModule.css;
+      // Also set on window for consistency
+      window.LitElement = LitElement;
+      window.html = html;
+      window.css = css;
+      console.log('[Media Card] Loaded Lit from CDN');
+    } catch (e) {
+      console.error('[Media Card] Failed to load Lit:', e);
+      console.error('[Media Card] For offline use, preload Lit before this card. See docs/OFFLINE_MODE.md');
+      return; // Can't continue without Lit
+    }
+  }
+`;
+
+function transformSource(file) {
+  return readFileSync(join(root, file), 'utf8')
+    .replace(/^import\s+[^;]+;\n/gm, '')
+    .replace(/^export\s+class\s+/gm, 'class ')
+    .replace(/^export\s+const\s+/gm, 'const ')
+    .replaceAll('__VERSION__', version)
+    .trimEnd();
+}
+
+const body = sourceFiles.map(transformSource).join('\n');
+const bannerStart = '/** ';
+const bundle = `${bannerStart}
+ * Media Card v${version}
+ */
+
+${litLoader}${body}
+
+})();
+`;
+
+writeFileSync(join(root, 'ha-media-card.js'), bundle);
+console.log(`Built ha-media-card.js v${version} from ${sourceFiles.length} source files`);

--- a/src/core/media-utils.js
+++ b/src/core/media-utils.js
@@ -25,7 +25,7 @@ export const MediaUtils = {
     
     if (['mp4', 'webm', 'ogg', 'mov', 'm4v'].includes(extension)) {
       return 'video';
-    } else if (['jpg', 'jpeg', 'png', 'gif', 'webp', 'svg', 'bmp', 'heic'].includes(extension)) {
+    } else if (['jpg', 'jpeg', 'png', 'gif', 'webp', 'svg', 'bmp', 'heic', 'heif'].includes(extension)) {
       return 'image';
     }
     

--- a/src/editor/media-card-editor.js
+++ b/src/editor/media-card-editor.js
@@ -4068,7 +4068,7 @@ Tip: Check your Home Assistant media folder in Settings > System > Storage`;
                   .checked=${this._config.show_cast_button === true}
                   @change=${this._showCastButtonChanged}
                 />
-                <div class="help-text">Show a cast icon to mirror this card to any media_player entity (LG, Chromecast, etc.) in real time (requires media_index)</div>
+                <div class="help-text">Show a cast icon to mirror this card to any media_player entity in real time. Roku uses media_index.roku_ecp_cast (requires media_index). Other players (LG, Chromecast, etc.) use media_player.play_media directly.</div>
               </div>
             </div>
           </div>

--- a/src/editor/media-card-editor.js
+++ b/src/editor/media-card-editor.js
@@ -1339,6 +1339,13 @@ export class MediaCardEditor extends LitElement {
     this._fireConfigChanged();
   }
 
+  _showCastButtonChanged(ev) {
+    this._config = ev.target.checked
+      ? { ...this._config, show_cast_button: true }
+      : (() => { const c = { ...this._config }; delete c.show_cast_button; return c; })();
+    this._fireConfigChanged();
+  }
+
   _actionButtonsEnableQueuePreviewChanged(ev) {
     this._config = {
       ...this._config,
@@ -4050,6 +4057,18 @@ Tip: Check your Home Assistant media folder in Settings > System > Storage`;
                   @change=${this._actionButtonsHideOnThisDayButtonChanged}
                 />
                 <div class="help-text">Hide the Through the Years action button; the feature remains accessible via the clock/date overlay</div>
+              </div>
+            </div>
+
+            <div class="config-row">
+              <label>Cast to TV Button</label>
+              <div>
+                <input
+                  type="checkbox"
+                  .checked=${this._config.show_cast_button === true}
+                  @change=${this._showCastButtonChanged}
+                />
+                <div class="help-text">Show a cast icon to mirror this card to any media_player entity (LG, Chromecast, etc.) in real time (requires media_index)</div>
               </div>
             </div>
           </div>

--- a/src/editor/media-card-editor.js
+++ b/src/editor/media-card-editor.js
@@ -2787,6 +2787,44 @@ Tip: Check your Home Assistant media folder in Settings > System > Storage`;
       color: var(--primary-text-color);
     }
 
+    .integration-callout {
+      background: var(--primary-background-color, #fafafa);
+      padding: 16px;
+      border-radius: 8px;
+      margin-bottom: 20px;
+      border: 1px solid var(--divider-color, #e0e0e0);
+    }
+
+    .integration-callout-title {
+      margin-bottom: 12px;
+      font-weight: 600;
+      color: var(--primary-text-color);
+    }
+
+    .integration-callout p {
+      margin: 4px 0 12px 0;
+      font-size: 13px;
+      color: var(--secondary-text-color, #666);
+      line-height: 1.45;
+    }
+
+    .integration-callout a {
+      color: var(--primary-color, #007bff);
+      text-decoration: none;
+      font-weight: 500;
+    }
+
+    .integration-callout a:hover {
+      text-decoration: underline;
+    }
+
+    .integration-callout code {
+      background: var(--code-background-color, rgba(0,0,0,0.1));
+      padding: 1px 4px;
+      border-radius: 3px;
+      font-size: 12px;
+    }
+
     .support-footer {
       margin-top: 24px;
       padding: 16px;
@@ -2903,6 +2941,24 @@ Tip: Check your Home Assistant media folder in Settings > System > Storage`;
             </div>
           ` : ''}
         </div>
+
+        ${isFolderMode ? html`
+          <div class="integration-callout">
+            <div class="integration-callout-title">iCloud Photos Sync</div>
+            <p>
+              To display iCloud Photos here, install the
+              <a href="https://github.com/anciltech/ha-icloud-photo-sync" target="_blank" rel="noopener noreferrer">AncilTech iCloud Photo Sync add-on</a>
+              from the Home Assistant Add-on Store repositories. The add-on downloads selected albums into
+              <code>/media/icloud_photos</code>; this card handles display.
+            </p>
+            <p>
+              After the add-on syncs, use
+              <code>media-source://media_source/local/icloud_photos</code>
+              as the folder path, or append an album folder such as
+              <code>/Favorites</code>.
+            </p>
+          </div>
+        ` : ''}
 
         <!-- Filters Section (available when Media Index is enabled) -->
         ${hasMediaIndex && isFolderMode && folderConfig.use_media_index_for_discovery !== false ? html`

--- a/src/providers/sequential-media-index-provider.js
+++ b/src/providers/sequential-media-index-provider.js
@@ -25,6 +25,7 @@ export class SequentialMediaIndexProvider extends MediaProvider {
     // Prevents further navigation attempts and unnecessary service calls
     this.reachedEnd = false;
     this.disableAutoLoop = false; // V5.3: Prevent auto-loop during pre-load
+    this._dbCleanupWarningShown = false; // Show DB cleanup warning at most once per session
   }
 
   _log(...args) {
@@ -141,7 +142,9 @@ export class SequentialMediaIndexProvider extends MediaProvider {
       this.lastSeenValue = null;
       this.reachedEnd = false;
       this.hasMore = true;
-      this.excludedFiles.clear(); // Clear excluded files when looping back
+      // Don't clear 404 exclusions on loop-back — files missing from disk stay missing.
+      // Keeping them in excludedFiles lets _queryOrderedFiles() skip past them efficiently
+      // on the next pass instead of re-fetching the same stale DB entries.
       
       const items = await this._queryOrderedFiles();
       if (items && items.length > 0) {
@@ -162,6 +165,18 @@ export class SequentialMediaIndexProvider extends MediaProvider {
       while (item && this._isExcluded(item.path)) {
         this._log(`⏭️ Skipping excluded file in getNext: ${item.path}`);
         if (this.queue.length === 0) {
+          if (this.hasMore && !this.reachedEnd) {
+            // Queue drained by 404-skipping before the top-of-function low-water refill fired.
+            // Fetch the next batch now rather than returning null and triggering a cursor reset.
+            this._log('⚠️ Queue empty while skipping excluded files — fetching next batch...');
+            const moreItems = await this._queryOrderedFiles();
+            if (moreItems && moreItems.length > 0) {
+              this.queue.push(...moreItems);
+              item = this.queue.shift();
+              if (!item) break;
+              continue;
+            }
+          }
           this._log('⚠️ Queue exhausted while skipping excluded files');
           return null;
         }
@@ -258,6 +273,7 @@ export class SequentialMediaIndexProvider extends MediaProvider {
       // folder won't halt iteration; only a pathological config (everything excluded) will stop it.
       let consecutiveAllExcludedBatches = 0;
       const MAX_CONSECUTIVE_EXCLUDED = 20; // Give up after 20 fully-excluded batches in a row
+      const DB_CLEANUP_WARNING_THRESHOLD = 5; // Warn user after 5 consecutive fully-excluded batches (1250+ missing files)
       // Overall iteration cap: limits worst-case WebSocket calls when excluded_paths leaves
       // only a few valid items per batch (not all-excluded, so consecutive counter keeps resetting).
       // 20 iterations × queueSize items/batch gives a reasonable upper bound on backend load.
@@ -417,6 +433,13 @@ export class SequentialMediaIndexProvider extends MediaProvider {
         const validFromThisBatch = filteredItems.length;
         if (validFromThisBatch === 0 && response.items.length > 0) {
           consecutiveAllExcludedBatches++;
+          if (consecutiveAllExcludedBatches >= DB_CLEANUP_WARNING_THRESHOLD && !this._dbCleanupWarningShown) {
+            this._dbCleanupWarningShown = true;
+            const missingCount = consecutiveAllExcludedBatches * this.queueSize;
+            const warningMsg = `⚠️ Media Index: ${missingCount}+ missing files detected in database. Run the cleanup_database service to remove stale entries.`;
+            console.warn(`[SequentialMediaIndexProvider] ${warningMsg}`);
+            this.card?._showToast(warningMsg, 7000);
+          }
           if (consecutiveAllExcludedBatches >= MAX_CONSECUTIVE_EXCLUDED) {
             this._log(`⚠️ Stopping after ${MAX_CONSECUTIVE_EXCLUDED} consecutive fully-excluded batches - excluded_paths may be too broad`);
             break;

--- a/src/providers/sequential-media-index-provider.js
+++ b/src/providers/sequential-media-index-provider.js
@@ -268,6 +268,19 @@ export class SequentialMediaIndexProvider extends MediaProvider {
       let allFilteredItems = [];
       let seenPaths = new Set(); // Track paths we've already added to avoid duplicates
       let iteration = 0;
+
+      // Resolve date range filters from config (supports static dates or HA entity IDs)
+      const _resolveDateFilter = (configValue) => {
+        if (!configValue) return null;
+        if (typeof configValue === 'string' && configValue.includes('.')) {
+          // Entity ID — look up current state
+          const state = this.hass?.states[configValue];
+          return state?.state?.split(' ')[0] || null;
+        }
+        return configValue;
+      };
+      const dateFrom = _resolveDateFilter(this.config.filters?.date_range?.start);
+      const dateTo = _resolveDateFilter(this.config.filters?.date_range?.end);
       // Track consecutive batches where ALL items were excluded - used as a safety escape valve.
       // Resets to 0 whenever a batch yields at least one valid item, so a single large excluded
       // folder won't halt iteration; only a pathological config (everything excluded) will stop it.
@@ -294,7 +307,9 @@ export class SequentialMediaIndexProvider extends MediaProvider {
           // V5 FEATURE: Priority new files - prepend recently indexed files to results
           // Note: Recently indexed = newly discovered by scanner, not necessarily new files
           priority_new_files: this.config.folder?.priority_new_files || false,
-          new_files_threshold_seconds: this.config.folder?.new_files_threshold_seconds || 3600
+          new_files_threshold_seconds: this.config.folder?.new_files_threshold_seconds || 3600,
+          ...(dateFrom ? { date_from: dateFrom } : {}),
+          ...(dateTo ? { date_to: dateTo } : {}),
         };
         
         // Add compound cursor for pagination (if we've seen items before)

--- a/src/ui/media-card.js
+++ b/src/ui/media-card.js
@@ -4116,9 +4116,66 @@ export class MediaCard extends LitElement {
     this._livePhotoPhase = 'still';
     const stillMs = Math.max(0.1, Number(this.config.live_photo?.still_duration) || 1) * 1000;
 
+    this._warmLivePhotoCompanion(generation, itemId);
+
     this._livePhotoTimer = setTimeout(() => {
       this._startLivePhotoVideo(generation, itemId);
     }, stillMs);
+  }
+
+  async _warmLivePhotoCompanion(generation, itemId) {
+    try {
+      const companion = await this._resolveLivePhotoCompanion(this.currentMedia);
+      if (!companion ||
+          generation !== this._livePhotoGeneration ||
+          itemId !== this._getLivePhotoItemId(this.currentMedia) ||
+          this.config?.live_photo?.preload_video === false) {
+        return;
+      }
+      await this._preloadLivePhotoVideo(companion.url, generation, itemId);
+    } catch (error) {
+      this._log('🎞️ Live Photo warmup skipped:', error?.message || error);
+    }
+  }
+
+  async _preloadLivePhotoVideo(url, generation, itemId) {
+    if (!url || typeof document === 'undefined') return;
+
+    await new Promise(resolve => {
+      const video = document.createElement('video');
+      let settled = false;
+      const cleanup = () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeout);
+        video.removeEventListener('loadedmetadata', onReady);
+        video.removeEventListener('canplay', onReady);
+        video.removeEventListener('error', onDone);
+        video.removeAttribute('src');
+        video.load?.();
+        resolve();
+      };
+      const isCurrent = () =>
+        generation === this._livePhotoGeneration &&
+        itemId === this._getLivePhotoItemId(this.currentMedia);
+      const onReady = () => cleanup();
+      const onDone = () => cleanup();
+      const timeout = setTimeout(cleanup, 3000);
+
+      if (!isCurrent()) {
+        cleanup();
+        return;
+      }
+
+      video.preload = 'auto';
+      video.muted = true;
+      video.playsInline = true;
+      video.addEventListener('loadedmetadata', onReady, { once: true });
+      video.addEventListener('canplay', onReady, { once: true });
+      video.addEventListener('error', onDone, { once: true });
+      video.src = url;
+      video.load();
+    });
   }
 
   async _startLivePhotoVideo(generation, itemId) {

--- a/src/ui/media-card.js
+++ b/src/ui/media-card.js
@@ -190,6 +190,8 @@ export class MediaCard extends LitElement {
     this._isLoadingNext = false;  // Re-entrance guard for _loadNext()
     this._isManualNavigation = false; // V5.6.7: Track if navigation is user-initiated vs timer-driven
     this._manualNavLoading = false;    // True from navigation commit until _onMediaLoaded/_onVideoCanPlay fires
+    this._swipeTouchStartX = null;    // Touch start X for swipe gesture detection
+    this._swipeTouchStartY = null;    // Touch start Y for swipe gesture detection
     
     // V5.6.0: Play randomized option for panels
     this._playRandomized = false;      // Toggle for randomizing panel playback order
@@ -8583,6 +8585,40 @@ export class MediaCard extends LitElement {
     
     this._holdTriggered = false;
   }
+
+  _handleSwipeTouchStart(e) {
+    if (e.touches.length !== 1) return;
+    this._swipeTouchStartX = e.touches[0].clientX;
+    this._swipeTouchStartY = e.touches[0].clientY;
+  }
+
+  _handleSwipeTouchEnd(e) {
+    if (this._swipeTouchStartX === null) return;
+    const deltaX = e.changedTouches[0].clientX - this._swipeTouchStartX;
+    const deltaY = e.changedTouches[0].clientY - this._swipeTouchStartY;
+    this._swipeTouchStartX = null;
+    this._swipeTouchStartY = null;
+
+    // Require min horizontal distance and horizontal must dominate vertical
+    const SWIPE_THRESHOLD = 50;
+    if (Math.abs(deltaX) < SWIPE_THRESHOLD || Math.abs(deltaX) <= Math.abs(deltaY)) return;
+
+    // Horizontal swipe confirmed — suppress the synthetic click and hold action
+    e.preventDefault();
+    if (this._holdTimeout) {
+      clearTimeout(this._holdTimeout);
+      this._holdTimeout = null;
+    }
+
+    this._isManualNavigation = true;
+    if (deltaX > 0) {
+      // Swipe right → go back
+      this._loadPrevious();
+    } else {
+      // Swipe left → go forward
+      this._loadNext();
+    }
+  }
   
   _handlePointerUp(e) {
     if (this._holdTimeout) {
@@ -11229,6 +11265,8 @@ export class MediaCard extends LitElement {
         @pointerdown=${this._handlePointerDown}
         @pointerup=${this._handlePointerUp}
         @pointercancel=${this._handlePointerCancel}
+        @touchstart=${this._handleSwipeTouchStart}
+        @touchend=${this._handleSwipeTouchEnd}
       >
         ${isVideo ? html`
           <video

--- a/src/ui/media-card.js
+++ b/src/ui/media-card.js
@@ -291,6 +291,9 @@ export class MediaCard extends LitElement {
     this._livePhotoCompanionVideoCache = new Map();
     this._livePhotoGeneration = 0;
 
+    this._heicObjectUrlCache = new Map();
+    this._heicConverterPromise = null;
+
     this._log('💎 Constructor called, cardId:', this._cardId);
   }
 
@@ -444,6 +447,7 @@ export class MediaCard extends LitElement {
     
     // Cleanup Live Photo playback timers
     this._clearLivePhotoPlayback();
+    this._revokeHeicObjectUrls();
   }
 
   // V4: Force video reload when URL changes
@@ -927,6 +931,13 @@ export class MediaCard extends LitElement {
         still_extensions: ['JPG', 'jpg', 'JPEG', 'jpeg', 'PNG', 'png', 'WEBP', 'webp'],
         hide_companion_videos: true,
         ...config.live_photo
+      },
+      heic: {
+        enabled: true,
+        library_url: 'https://cdn.jsdelivr.net/npm/heic2any@0.0.4/dist/heic2any.min.js',
+        output_type: 'image/jpeg',
+        quality: 0.92,
+        ...config.heic
       },
       // V5.6: Clock/Date Overlay defaults
       clock: {
@@ -2919,6 +2930,108 @@ export class MediaCard extends LitElement {
     return null; // Provider doesn't support file existence checks
   }
 
+  _isHeicMedia(pathOrItem = this.currentMedia) {
+    const path = typeof pathOrItem === 'string'
+      ? pathOrItem
+      : (
+          pathOrItem?.media_content_id ||
+          pathOrItem?.media_source_uri ||
+          pathOrItem?.path ||
+          pathOrItem?.title ||
+          ''
+        );
+    const cleanPath = (path || '').split('?')[0].split('|')[0].toLowerCase();
+    return cleanPath.endsWith('.heic') || cleanPath.endsWith('.heif');
+  }
+
+  _revokeHeicObjectUrls() {
+    if (!this._heicObjectUrlCache) return;
+
+    for (const objectUrl of this._heicObjectUrlCache.values()) {
+      URL.revokeObjectURL(objectUrl);
+    }
+
+    this._heicObjectUrlCache.clear();
+  }
+
+  _loadHeicConverter() {
+    if (window.heic2any) {
+      return Promise.resolve(window.heic2any);
+    }
+
+    if (this._heicConverterPromise) {
+      return this._heicConverterPromise;
+    }
+
+    const libraryUrl = this.config?.heic?.library_url ||
+      'https://cdn.jsdelivr.net/npm/heic2any@0.0.4/dist/heic2any.min.js';
+
+    this._heicConverterPromise = new Promise((resolve, reject) => {
+      const existingScript = document.querySelector(`script[data-ha-media-heic2any="${libraryUrl}"]`);
+      if (existingScript) {
+        existingScript.addEventListener('load', () => resolve(window.heic2any), { once: true });
+        existingScript.addEventListener('error', reject, { once: true });
+        return;
+      }
+
+      const script = document.createElement('script');
+      script.src = libraryUrl;
+      script.async = true;
+      script.dataset.haMediaHeic2any = libraryUrl;
+      script.onload = () => {
+        if (window.heic2any) {
+          resolve(window.heic2any);
+        } else {
+          reject(new Error('heic2any loaded without exposing window.heic2any'));
+        }
+      };
+      script.onerror = () => reject(new Error(`Failed to load HEIC converter: ${libraryUrl}`));
+      document.head.appendChild(script);
+    });
+
+    return this._heicConverterPromise;
+  }
+
+  async _prepareHeicDisplayUrl(url, expectedNavigationIndex) {
+    if (this.config?.heic?.enabled === false || (!this._isHeicMedia(this.currentMedia) && !this._isHeicMedia(url))) {
+      return url;
+    }
+
+    if (this._heicObjectUrlCache?.has(url)) {
+      return this._heicObjectUrlCache.get(url);
+    }
+
+    try {
+      this._log('🖼️ Converting HEIC image for browser display:', this.currentMedia?.media_content_id || url);
+      const converter = await this._loadHeicConverter();
+      const response = await fetch(url, { credentials: 'same-origin' });
+      if (!response.ok) {
+        throw new Error(`HEIC fetch failed with ${response.status}`);
+      }
+
+      const inputBlob = await response.blob();
+      const outputBlob = await converter({
+        blob: inputBlob,
+        toType: this.config?.heic?.output_type || 'image/jpeg',
+        quality: Number(this.config?.heic?.quality) || 0.92
+      });
+      const finalBlob = Array.isArray(outputBlob) ? outputBlob[0] : outputBlob;
+      const objectUrl = URL.createObjectURL(finalBlob);
+
+      const currentNavIndex = this._pendingNavigationIndex ?? this.navigationIndex;
+      if (expectedNavigationIndex !== undefined && currentNavIndex !== expectedNavigationIndex) {
+        URL.revokeObjectURL(objectUrl);
+        return '';
+      }
+
+      this._heicObjectUrlCache.set(url, objectUrl);
+      return objectUrl;
+    } catch (error) {
+      console.warn('[MediaCard] HEIC conversion failed, falling back to native image support:', error);
+      return url;
+    }
+  }
+
   // V5.6: Helper to set mediaUrl with crossfade transition (validates first for images)
   async _setMediaUrl(url, expectedNavigationIndex) {
     // V5.6.7: Guard against stale async resolutions during rapid navigation
@@ -2952,6 +3065,7 @@ export class MediaCard extends LitElement {
     // layers get cleared, _renderMedia renders nothing, _onMediaLoaded never fires, and
     // _navigatingAway stays true — freezing the slideshow timer permanently.
     const isVideo = this._isVideoFile(url) || this._isCurrentItemVideo(url);
+    let displayUrl = url;
     
     // For images, validate they exist before displaying (MediaIndexProvider only)
     if (!isVideo) {
@@ -2971,9 +3085,14 @@ export class MediaCard extends LitElement {
       }
       // If providerCheckResult is null, provider doesn't support checks (FolderProvider, SingleMediaProvider)
       // These providers discover files from disk, so 404s are unlikely - proceed without validation
+
+      displayUrl = await this._prepareHeicDisplayUrl(url, expectedNavigationIndex);
+      if (!displayUrl) {
+        return;
+      }
     }
     
-    this.mediaUrl = url;
+    this.mediaUrl = displayUrl;
     
     if (!isVideo) {
       const duration = this.config?.transition?.duration ?? 300;
@@ -2996,7 +3115,7 @@ export class MediaCard extends LitElement {
         // This handles rapid navigation where the previous image hasn't loaded yet
         if (!this._frontLayerUrl && !this._backLayerUrl) {
           // Special case: Both layers empty (first load or after video), show immediately without crossfade
-          this._frontLayerUrl = url;
+          this._frontLayerUrl = displayUrl;
           this._frontLayerActive = true;
           this._pendingLayerSwap = false;
           this._frontLayerNavigationIndex = expectedNavigationIndex;
@@ -3004,7 +3123,7 @@ export class MediaCard extends LitElement {
         } else if (this._pendingLayerSwap) {
           // Rapid navigation: Previous image hasn't loaded yet. Clear both and start fresh.
           this._log(`⏩ Rapid navigation detected - clearing both layers`);
-          this._frontLayerUrl = url;
+          this._frontLayerUrl = displayUrl;
           this._frontLayerGeneration++; // Invalidate any pending setTimeout for front layer
           this._backLayerUrl = '';
           this._backLayerGeneration++; // Invalidate any pending setTimeout for back layer
@@ -3016,11 +3135,11 @@ export class MediaCard extends LitElement {
         } else {
           // Normal crossfade: load on hidden layer then swap
           if (this._frontLayerActive) {
-            this._backLayerUrl = url;
+            this._backLayerUrl = displayUrl;
             this._backLayerGeneration++; // Increment to invalidate any pending setTimeout for this layer
             this._backLayerNavigationIndex = expectedNavigationIndex;
           } else {
-            this._frontLayerUrl = url;
+            this._frontLayerUrl = displayUrl;
             this._frontLayerGeneration++; // Increment to invalidate any pending setTimeout for this layer
             this._frontLayerNavigationIndex = expectedNavigationIndex;
           }

--- a/src/ui/media-card.js
+++ b/src/ui/media-card.js
@@ -126,6 +126,7 @@ export class MediaCard extends LitElement {
         pause_duration: 10,
         video_suffixes: ['_HEVC', '-HEVC', ''],
         video_extensions: ['MOV', 'mov', 'mp4', 'MP4', 'm4v', 'M4V'],
+        still_extensions: ['JPG', 'jpg', 'JPEG', 'jpeg', 'PNG', 'png', 'WEBP', 'webp'],
         hide_companion_videos: true,
         ...config.live_photo
       }
@@ -287,6 +288,7 @@ export class MediaCard extends LitElement {
     this._livePhotoVideoReady = false;
     this._livePhotoTimer = null;
     this._livePhotoCompanionCache = new Map();
+    this._livePhotoCompanionVideoCache = new Map();
     this._livePhotoGeneration = 0;
 
     this._log('💎 Constructor called, cardId:', this._cardId);
@@ -922,6 +924,7 @@ export class MediaCard extends LitElement {
         pause_duration: 10,
         video_suffixes: ['_HEVC', '-HEVC', ''],
         video_extensions: ['MOV', 'mov', 'mp4', 'MP4', 'm4v', 'M4V'],
+        still_extensions: ['JPG', 'jpg', 'JPEG', 'jpeg', 'PNG', 'png', 'WEBP', 'webp'],
         hide_companion_videos: true,
         ...config.live_photo
       },
@@ -1560,7 +1563,7 @@ export class MediaCard extends LitElement {
           const _syncGenBefore = this._syncNavGeneration || 0;
           let item = await this.provider.getNext();
           let hiddenCompanionAttempts = 0;
-          while (item && this._shouldHideLivePhotoCompanionVideo(item) && hiddenCompanionAttempts < 25) {
+          while (item && await this._shouldHideLivePhotoCompanionVideo(item) && hiddenCompanionAttempts < 25) {
             this._log('🎞️ Skipping Live Photo companion video in slideshow queue:', item.media_content_id);
             item = await this.provider.getNext();
             hiddenCompanionAttempts++;
@@ -1578,7 +1581,7 @@ export class MediaCard extends LitElement {
               this._log(`⚠️ Item already in navigation queue (attempt ${attempts + 1}), getting next:`, item.media_content_id);
               item = await this.provider.getNext();
               hiddenCompanionAttempts = 0;
-              while (item && this._shouldHideLivePhotoCompanionVideo(item) && hiddenCompanionAttempts < 25) {
+              while (item && await this._shouldHideLivePhotoCompanionVideo(item) && hiddenCompanionAttempts < 25) {
                 this._log('🎞️ Skipping Live Photo companion video in slideshow queue:', item.media_content_id);
                 item = await this.provider.getNext();
                 hiddenCompanionAttempts++;
@@ -1684,7 +1687,7 @@ export class MediaCard extends LitElement {
         return;
       }
       
-      if (this._shouldHideLivePhotoCompanionVideo(item)) {
+      if (await this._shouldHideLivePhotoCompanionVideo(item)) {
         this._log('🎞️ Removing Live Photo companion video from navigation queue:', item.media_content_id);
         this._removeItemFromQueues(item);
         this._isLoadingNext = false;
@@ -3612,7 +3615,71 @@ export class MediaCard extends LitElement {
            MediaUtils.detectFileType(item.title || '') === 'image';
   }
 
-  _shouldHideLivePhotoCompanionVideo(item) {
+  _buildLivePhotoStillCandidatesForVideo(item) {
+    const mediaId = this._getLivePhotoItemId(item);
+    if (!mediaId) return [];
+
+    const cleanId = mediaId.split('?')[0];
+    const slashIndex = cleanId.lastIndexOf('/');
+    const dotIndex = cleanId.lastIndexOf('.');
+    if (dotIndex <= slashIndex) return [];
+
+    const basePath = cleanId.substring(0, dotIndex);
+    const basePaths = new Set([basePath]);
+    const suffixes = this.config?.live_photo?.video_suffixes || ['_HEVC', '-HEVC', ''];
+    for (const suffix of suffixes) {
+      if (suffix && basePath.toLowerCase().endsWith(String(suffix).toLowerCase())) {
+        basePaths.add(basePath.substring(0, basePath.length - String(suffix).length));
+      }
+    }
+
+    const stillExtensions = this.config?.live_photo?.still_extensions ||
+      ['JPG', 'jpg', 'JPEG', 'jpeg', 'PNG', 'png', 'WEBP', 'webp'];
+    const candidates = [];
+    const seen = new Set();
+    for (const stillBasePath of basePaths) {
+      for (const extension of stillExtensions) {
+        const candidate = `${stillBasePath}.${extension}`;
+        if (!seen.has(candidate)) {
+          candidates.push(candidate);
+          seen.add(candidate);
+        }
+      }
+    }
+    return candidates;
+  }
+
+  async _hasLivePhotoStillForVideo(item) {
+    const itemId = this._getLivePhotoItemId(item);
+    if (!itemId || !this.hass) return false;
+
+    if (this._livePhotoCompanionVideoCache.has(itemId)) {
+      return this._livePhotoCompanionVideoCache.get(itemId);
+    }
+
+    for (const candidate of this._buildLivePhotoStillCandidatesForVideo(item)) {
+      const mediaContentId = candidate.startsWith('/media/')
+        ? `media-source://media_source${candidate}`
+        : candidate;
+      try {
+        await this.hass.callWS({
+          type: 'media_source/resolve_media',
+          media_content_id: mediaContentId,
+          expires: 60
+        });
+        this._livePhotoCompanionVideoCache.set(itemId, true);
+        this._log('🎞️ Live Photo still found for companion video:', mediaContentId);
+        return true;
+      } catch (error) {
+        // Candidate does not exist or is not resolvable; try the next still extension.
+      }
+    }
+
+    this._livePhotoCompanionVideoCache.set(itemId, false);
+    return false;
+  }
+
+  async _shouldHideLivePhotoCompanionVideo(item) {
     if (!this._isLivePhotoEnabled() || this.config?.live_photo?.hide_companion_videos === false) {
       return false;
     }
@@ -3620,9 +3687,10 @@ export class MediaCard extends LitElement {
 
     const baseName = this._getLivePhotoBaseName(item).toLowerCase();
     const suffixes = this.config?.live_photo?.video_suffixes || ['_HEVC', '-HEVC'];
-    return suffixes
+    const hasCompanionSuffix = suffixes
       .filter(suffix => suffix && String(suffix).length > 0)
       .some(suffix => baseName.endsWith(String(suffix).toLowerCase()));
+    return hasCompanionSuffix || await this._hasLivePhotoStillForVideo(item);
   }
 
   _removeItemFromQueues(item) {

--- a/src/ui/media-card.js
+++ b/src/ui/media-card.js
@@ -291,6 +291,7 @@ export class MediaCard extends LitElement {
     this._livePhotoTimer = null;
     this._livePhotoCompanionCache = new Map();
     this._livePhotoCompanionVideoCache = new Map();
+    this._livePhotoNegativeCacheMs = 5 * 60 * 1000;
     this._livePhotoGeneration = 0;
 
     this._heicObjectUrlCache = new Map();
@@ -834,6 +835,8 @@ export class MediaCard extends LitElement {
       this._refreshInterval = null;
     }
     this._clearLivePhotoPlayback();
+    this._livePhotoCompanionCache?.clear();
+    this._livePhotoCompanionVideoCache?.clear();
     
     // V5: Validate and clamp max_height_pixels if present
     if (config.max_height_pixels !== undefined) {
@@ -1251,6 +1254,7 @@ export class MediaCard extends LitElement {
           // Queue and index already set — jump directly to the saved item
           const item = this.navigationQueue[this.navigationIndex];
           if (item) {
+            this._clearLivePhotoPlayback();
             this.currentMedia = item;
             this._pendingNavigationIndex = this.navigationIndex;
             this._pendingMediaPath = item.media_content_id;
@@ -1264,6 +1268,7 @@ export class MediaCard extends LitElement {
           this._log('🔄 Reconnected with history - loading media at position', this.historyPosition);
           const historyItem = this.history[this.historyPosition];
           if (historyItem) {
+            this._clearLivePhotoPlayback();
             this.currentMedia = historyItem;
             await this._resolveMediaUrl();
           } else {
@@ -1903,6 +1908,7 @@ export class MediaCard extends LitElement {
     }
     
     // Display the item
+    this._clearLivePhotoPlayback();
     this.currentMedia = item;
     
     // V5.6.7: Store in pending state - will apply when image/video loads (syncs all overlays)
@@ -2037,6 +2043,7 @@ export class MediaCard extends LitElement {
     
     // Update current media - THIS IS CRITICAL for main image display
     const mediaUri = item.media_source_uri || item.path;
+    this._clearLivePhotoPlayback();
     this.currentMedia = {
       media_content_id: mediaUri,
       media_content_type: item.filename?.toLowerCase().endsWith('.mp4') ? 'video' : 'image',
@@ -2092,6 +2099,7 @@ export class MediaCard extends LitElement {
 
     // Load the item from the queue
     const item = this.navigationQueue[queueIndex];
+    this._clearLivePhotoPlayback();
     this.currentMedia = item;
     
     // V5.6.7: Store in pending state - will apply when image/video loads  
@@ -2491,6 +2499,7 @@ export class MediaCard extends LitElement {
     }
     
     // Display the media (same pattern as _loadNext)
+    this._clearLivePhotoPlayback();
     this.currentMedia = currentItem;
     this._pendingMediaPath = currentItem.media_content_id;
     this._pendingMetadata = currentItem.metadata || null;
@@ -2802,6 +2811,7 @@ export class MediaCard extends LitElement {
         // Check if we should display this new first item
         const shouldUpdate = !currentMediaId || firstItem.media_content_id !== currentMediaId;
         
+        this._clearLivePhotoPlayback();
         this.currentMedia = firstItem;
         
         // CRITICAL: Update _currentMetadata and _currentMediaPath for overlay display
@@ -3976,13 +3986,22 @@ export class MediaCard extends LitElement {
     const itemId = this._getLivePhotoItemId(item);
     if (!itemId || !this.hass) return false;
 
-    if (this._livePhotoCompanionVideoCache.has(itemId)) {
-      return this._livePhotoCompanionVideoCache.get(itemId) === true;
+    const cached = this._livePhotoCompanionVideoCache.get(itemId);
+    if (cached === true) {
+      return true;
+    }
+    if (cached && cached.value === false) {
+      if (Date.now() - cached.checkedAt < this._livePhotoNegativeCacheMs) {
+        return false;
+      }
+      this._livePhotoCompanionVideoCache.delete(itemId);
+    } else if (cached === false) {
+      return false;
     }
 
     const candidates = this._buildLivePhotoStillCandidatesForVideo(item);
     if (!candidates.length) {
-      this._livePhotoCompanionVideoCache.set(itemId, false);
+      this._livePhotoCompanionVideoCache.set(itemId, { value: false, checkedAt: Date.now() });
       return false;
     }
 
@@ -4004,7 +4023,7 @@ export class MediaCard extends LitElement {
       }
     }
 
-    this._livePhotoCompanionVideoCache.set(itemId, false);
+    this._livePhotoCompanionVideoCache.set(itemId, { value: false, checkedAt: Date.now() });
     return false;
   }
 
@@ -4947,6 +4966,7 @@ export class MediaCard extends LitElement {
     this._log(`🔗 Shared queue synced on reconnect: ${this.navigationQueue.length} items, index ${newIndex}`);
     if (newPath !== this._currentMediaPath) {
       const item = this.navigationQueue[newIndex];
+      this._clearLivePhotoPlayback();
       this.currentMedia = item;
       this._pendingNavigationIndex = newIndex;
       this._pendingMediaPath = newPath;
@@ -5332,6 +5352,7 @@ export class MediaCard extends LitElement {
     }));
     this.navigationIndex = newIndex;
     const item = this.navigationQueue[newIndex];
+    this._clearLivePhotoPlayback();
     this.currentMedia = item;
     this._pendingNavigationIndex = newIndex;
     this._pendingMediaPath = newPath;
@@ -8695,6 +8716,7 @@ export class MediaCard extends LitElement {
         const restoredItem = this.navigationQueue[this.navigationIndex];
         if (restoredItem) {
           // Properly restore display state (same as _loadNext)
+          this._clearLivePhotoPlayback();
           this.currentMedia = restoredItem;
           this._currentMediaPath = restoredItem.media_content_id;
           this._currentMetadata = restoredItem.metadata || null;

--- a/src/ui/media-card.js
+++ b/src/ui/media-card.js
@@ -8640,7 +8640,7 @@ export class MediaCard extends LitElement {
     }
   }
 
-  _showToast(message) {
+  _showToast(message, duration = 2000) {
     // V4 CODE: Simple toast notification (line 5470-5492)
     const toast = document.createElement('div');
     toast.textContent = message;
@@ -8662,7 +8662,7 @@ export class MediaCard extends LitElement {
     
     setTimeout(() => {
       toast.remove();
-    }, 2000);
+    }, duration);
   }
 
   // NEW: Auto-enable kiosk mode monitoring

--- a/src/ui/media-card.js
+++ b/src/ui/media-card.js
@@ -3241,7 +3241,7 @@ export class MediaCard extends LitElement {
     // V5.6.7: Guard against stale async resolutions during rapid navigation
     // If expectedNavigationIndex is provided and doesn't match current pending index, abort
     if (!this._isNavigationCurrent(expectedNavigationIndex, expectedGeneration)) {
-      this._log(`⏭️ Skipping stale media resolution (expected: ${expectedNavigationIndex}, current: ${this._pendingNavigationIndex})`);
+      this._log(`⏭️ Skipping stale media resolution (expected index: ${expectedNavigationIndex}, current index: ${this._pendingNavigationIndex}, expected generation: ${expectedGeneration}, current generation: ${this._navigationGeneration})`);
       // Clear the navigation-in-progress flag when nothing else has claimed a pending
       // path (i.e. no sync nav or newer _loadNext() is in flight). Without this,
       // a stale return from a _loadNext() call that was superseded by a rapid sync
@@ -3562,13 +3562,9 @@ export class MediaCard extends LitElement {
   }
   
   _onMediaError(e) {
-    if (this._livePhotoPhase === 'video') {
-      const itemId = this._getLivePhotoItemId(this.currentMedia);
-      if (itemId) this._livePhotoCompanionCache.delete(itemId);
-      this._livePhotoPhase = 'idle';
-      this._livePhotoVideoUrl = '';
-      this._log('🎞️ Live Photo companion video failed - keeping still image visible');
-      this.requestUpdate();
+    const target = e?.target;
+    if (this._livePhotoPhase === 'video' && target?.classList?.contains('live-photo-video')) {
+      this._onLivePhotoVideoError(e);
       return;
     }
 
@@ -3576,7 +3572,6 @@ export class MediaCard extends LitElement {
     this._navigatingAway = false;
     
     // V4 comprehensive error handling
-    const target = e.target;
     const error = target?.error;
     
     let errorMessage = 'Media file not found';
@@ -3981,11 +3976,17 @@ export class MediaCard extends LitElement {
     const itemId = this._getLivePhotoItemId(item);
     if (!itemId || !this.hass) return false;
 
-    if (this._livePhotoCompanionVideoCache.get(itemId) === true) {
-      return true;
+    if (this._livePhotoCompanionVideoCache.has(itemId)) {
+      return this._livePhotoCompanionVideoCache.get(itemId) === true;
     }
 
-    for (const candidate of this._buildLivePhotoStillCandidatesForVideo(item)) {
+    const candidates = this._buildLivePhotoStillCandidatesForVideo(item);
+    if (!candidates.length) {
+      this._livePhotoCompanionVideoCache.set(itemId, false);
+      return false;
+    }
+
+    for (const candidate of candidates) {
       const mediaContentId = candidate.startsWith('/media/')
         ? `media-source://media_source${candidate}`
         : candidate;
@@ -4003,6 +4004,7 @@ export class MediaCard extends LitElement {
       }
     }
 
+    this._livePhotoCompanionVideoCache.set(itemId, false);
     return false;
   }
 

--- a/src/ui/media-card.js
+++ b/src/ui/media-card.js
@@ -96,6 +96,41 @@ export class MediaCard extends LitElement {
     };
   }
 
+  _applyICloudPhotosPreset(config) {
+    if (config?.icloud_photos?.enabled !== true) {
+      return config;
+    }
+
+    const icloudConfig = config.icloud_photos || {};
+    const basePath = icloudConfig.media_source_path || 'media-source://media_source/local/icloud_photos';
+    const album = icloudConfig.album || icloudConfig.photo_album || '';
+    const normalizedBasePath = basePath.replace(/\/$/, '');
+    const folderPath = album
+      ? `${normalizedBasePath}/${album}`
+      : normalizedBasePath;
+
+    return {
+      ...config,
+      media_source_type: 'folder',
+      media_type: config.media_type || 'all',
+      folder: {
+        mode: 'random',
+        recursive: true,
+        ...config.folder,
+        path: config.folder?.path || folderPath
+      },
+      live_photo: {
+        enabled: true,
+        still_duration: 1,
+        pause_duration: 10,
+        video_suffixes: ['_HEVC', '-HEVC', ''],
+        video_extensions: ['MOV', 'mov', 'mp4', 'MP4', 'm4v', 'M4V'],
+        hide_companion_videos: true,
+        ...config.live_photo
+      }
+    };
+  }
+
   constructor() {
     super();
     this.provider = null;
@@ -244,6 +279,13 @@ export class MediaCard extends LitElement {
     this._userMutePreference = null;      // null=no preference, true=muted, false=unmuted
     this._mutePreferenceTimestamp = 0;    // When user last changed preference
     this._suppressVolumeChangeHandler = false; // V5.8: True during programmatic mute toggles (suppresses native-control detection)
+    
+    // Live Photo playback state. Used for iCloud-style still + companion video pairs.
+    this._livePhotoPhase = 'idle';        // idle | still | video | pause
+    this._livePhotoVideoUrl = '';
+    this._livePhotoTimer = null;
+    this._livePhotoCompanionCache = new Map();
+    this._livePhotoGeneration = 0;
 
     this._log('💎 Constructor called, cardId:', this._cardId);
   }
@@ -395,6 +437,9 @@ export class MediaCard extends LitElement {
     
     // V5.6: Cleanup clock timer
     this._stopClockTimer();
+    
+    // Cleanup Live Photo playback timers
+    this._clearLivePhotoPlayback();
   }
 
   // V4: Force video reload when URL changes
@@ -768,6 +813,8 @@ export class MediaCard extends LitElement {
       config = this._migrateV4ConfigToV5a(config);
       this._log('✅ V4 config migrated:', config);
     }
+
+    config = this._applyICloudPhotosPreset(config);
     
     // V5: Clear auto-advance timer when reconfiguring (prevents duplicate timers)
     if (this._refreshInterval) {
@@ -775,6 +822,7 @@ export class MediaCard extends LitElement {
       clearInterval(this._refreshInterval);
       this._refreshInterval = null;
     }
+    this._clearLivePhotoPlayback();
     
     // V5: Validate and clamp max_height_pixels if present
     if (config.max_height_pixels !== undefined) {
@@ -864,6 +912,16 @@ export class MediaCard extends LitElement {
         recent_change_window: 60, // seconds
         ...config.display_entities
       },
+      // V5.11: Live Photo pairing/playback for still + companion video exports
+      live_photo: {
+        enabled: false,
+        still_duration: 1,
+        pause_duration: 10,
+        video_suffixes: ['_HEVC', '-HEVC', ''],
+        video_extensions: ['MOV', 'mov', 'mp4', 'MP4', 'm4v', 'M4V'],
+        hide_companion_videos: true,
+        ...config.live_photo
+      },
       // V5.6: Clock/Date Overlay defaults
       clock: {
         enabled: false,
@@ -882,7 +940,15 @@ export class MediaCard extends LitElement {
       // V5.6.12: Mute preference timeout (seconds) - how long user's mute choice persists
       mute_preference_timeout: config.mute_preference_timeout ?? 300,
       // V5.6.7: Edge fade strength (0 = disabled, 1-100 = enabled with fade intensity)
-      edge_fade_strength: config.edge_fade_strength ?? 0
+      edge_fade_strength: config.edge_fade_strength ?? 0,
+      // V5.11: iCloud Photos preset. Sync is handled server-side; the card owns display defaults.
+      icloud_photos: {
+        enabled: false,
+        media_source_path: 'media-source://media_source/local/icloud_photos',
+        album: '',
+        sync_backend: 'icloudpd',
+        ...config.icloud_photos
+      }
     };
     
     // V4: Set debug mode from config
@@ -1490,6 +1556,12 @@ export class MediaCard extends LitElement {
           // arrived from another card while we were waiting for the provider.
           const _syncGenBefore = this._syncNavGeneration || 0;
           let item = await this.provider.getNext();
+          let hiddenCompanionAttempts = 0;
+          while (item && this._shouldHideLivePhotoCompanionVideo(item) && hiddenCompanionAttempts < 25) {
+            this._log('🎞️ Skipping Live Photo companion video in slideshow queue:', item.media_content_id);
+            item = await this.provider.getNext();
+            hiddenCompanionAttempts++;
+          }
         
           if (item) {
             this._log('Got item from provider:', item.filename || item.media_content_id);
@@ -1502,6 +1574,12 @@ export class MediaCard extends LitElement {
             while (alreadyInQueue && attempts < maxAttempts) {
               this._log(`⚠️ Item already in navigation queue (attempt ${attempts + 1}), getting next:`, item.media_content_id);
               item = await this.provider.getNext();
+              hiddenCompanionAttempts = 0;
+              while (item && this._shouldHideLivePhotoCompanionVideo(item) && hiddenCompanionAttempts < 25) {
+                this._log('🎞️ Skipping Live Photo companion video in slideshow queue:', item.media_content_id);
+                item = await this.provider.getNext();
+                hiddenCompanionAttempts++;
+              }
               if (!item) break;
               alreadyInQueue = this.navigationQueue.some(q => q.media_content_id === item.media_content_id);
               attempts++;
@@ -1602,6 +1680,14 @@ export class MediaCard extends LitElement {
         this._log('ERROR: No item at navigationIndex', nextIndex);
         return;
       }
+      
+      if (this._shouldHideLivePhotoCompanionVideo(item)) {
+        this._log('🎞️ Removing Live Photo companion video from navigation queue:', item.media_content_id);
+        this._removeItemFromQueues(item);
+        this._isLoadingNext = false;
+        setTimeout(() => this._loadNext(), 0);
+        return;
+      }
 
       // V5.6.8: Increment periodic refresh counter and check if refresh needed
       // Works for both sequential and random modes - provider handles mode-specific logic
@@ -1652,6 +1738,7 @@ export class MediaCard extends LitElement {
       }
       
       // Display the item
+      this._clearLivePhotoPlayback();
       this.currentMedia = item;
       
       // V5.6.7: Store in pending state - will apply when image/video loads (syncs all overlays)
@@ -3141,6 +3228,16 @@ export class MediaCard extends LitElement {
   }
   
   _onMediaError(e) {
+    if (this._livePhotoPhase === 'video') {
+      const itemId = this._getLivePhotoItemId(this.currentMedia);
+      if (itemId) this._livePhotoCompanionCache.set(itemId, null);
+      this._livePhotoPhase = 'idle';
+      this._livePhotoVideoUrl = '';
+      this._log('🎞️ Live Photo companion video failed - keeping still image visible');
+      this.requestUpdate();
+      return;
+    }
+
     // V5.6.7: Clear navigation flag to prevent slideshow getting stuck on 404 errors
     this._navigatingAway = false;
     
@@ -3469,6 +3566,205 @@ export class MediaCard extends LitElement {
     }
   }
 
+  // V5.11: Live Photo helpers
+  _isLivePhotoEnabled() {
+    return this.config?.live_photo?.enabled === true;
+  }
+
+  _clearLivePhotoTimer() {
+    if (this._livePhotoTimer) {
+      clearTimeout(this._livePhotoTimer);
+      this._livePhotoTimer = null;
+    }
+  }
+
+  _clearLivePhotoPlayback() {
+    this._clearLivePhotoTimer();
+    this._livePhotoGeneration++;
+    this._livePhotoPhase = 'idle';
+    this._livePhotoVideoUrl = '';
+  }
+
+  _getLivePhotoItemId(item = this.currentMedia) {
+    return item?.media_content_id || item?.media_source_uri || item?.path || item?.metadata?.path || '';
+  }
+
+  _getLivePhotoFileName(itemOrPath) {
+    const path = typeof itemOrPath === 'string' ? itemOrPath : this._getLivePhotoItemId(itemOrPath);
+    const cleanPath = (path || '').split('?')[0].split('|')[0];
+    return cleanPath.split('/').pop() || cleanPath;
+  }
+
+  _getLivePhotoBaseName(itemOrPath) {
+    const filename = this._getLivePhotoFileName(itemOrPath);
+    const dotIndex = filename.lastIndexOf('.');
+    return dotIndex > 0 ? filename.substring(0, dotIndex) : filename;
+  }
+
+  _isImageItem(item) {
+    if (!item) return false;
+    if (item.media_content_type?.startsWith('image')) return true;
+    return MediaUtils.detectFileType(this._getLivePhotoItemId(item)) === 'image' ||
+           MediaUtils.detectFileType(item.title || '') === 'image';
+  }
+
+  _shouldHideLivePhotoCompanionVideo(item) {
+    if (!this._isLivePhotoEnabled() || this.config?.live_photo?.hide_companion_videos === false) {
+      return false;
+    }
+    if (!this._isVideoItem(item)) return false;
+
+    const baseName = this._getLivePhotoBaseName(item).toLowerCase();
+    const suffixes = this.config?.live_photo?.video_suffixes || ['_HEVC', '-HEVC'];
+    return suffixes
+      .filter(suffix => suffix && String(suffix).length > 0)
+      .some(suffix => baseName.endsWith(String(suffix).toLowerCase()));
+  }
+
+  _removeItemFromQueues(item) {
+    if (!item) return;
+    const itemId = item.media_content_id || item.media_source_uri || item.path;
+    const matches = (candidate) => {
+      const candidateId = candidate?.media_content_id || candidate?.media_source_uri || candidate?.path;
+      return candidate === item || (!!itemId && candidateId === itemId);
+    };
+
+    this.navigationQueue = (this.navigationQueue || []).filter(candidate => !matches(candidate));
+    this.history = (this.history || []).filter(candidate => !matches(candidate));
+    if (this._panelQueue?.length) {
+      this._panelQueue = this._panelQueue.filter(candidate => !matches(candidate));
+    }
+    if (this.provider?.queue?.length) {
+      this.provider.queue = this.provider.queue.filter(candidate => !matches(candidate));
+    }
+  }
+
+  _buildLivePhotoCompanionCandidates(item = this.currentMedia) {
+    const mediaId = this._getLivePhotoItemId(item);
+    if (!mediaId) return [];
+
+    const cleanId = mediaId.split('?')[0];
+    const slashIndex = cleanId.lastIndexOf('/');
+    const dotIndex = cleanId.lastIndexOf('.');
+    if (dotIndex <= slashIndex) return [];
+
+    const basePath = cleanId.substring(0, dotIndex);
+    const suffixes = this.config?.live_photo?.video_suffixes || ['_HEVC', '-HEVC', ''];
+    const extensions = this.config?.live_photo?.video_extensions || ['MOV', 'mov', 'mp4', 'MP4'];
+    const candidates = [];
+    const seen = new Set();
+
+    for (const suffix of suffixes) {
+      for (const extension of extensions) {
+        const candidate = `${basePath}${suffix || ''}.${extension}`;
+        if (!seen.has(candidate)) {
+          candidates.push(candidate);
+          seen.add(candidate);
+        }
+      }
+    }
+
+    return candidates;
+  }
+
+  async _resolveLivePhotoCompanion(item = this.currentMedia) {
+    const itemId = this._getLivePhotoItemId(item);
+    if (!itemId || !this.hass) return null;
+
+    if (this._livePhotoCompanionCache.has(itemId)) {
+      return this._livePhotoCompanionCache.get(itemId);
+    }
+
+    for (const candidate of this._buildLivePhotoCompanionCandidates(item)) {
+      const mediaContentId = candidate.startsWith('/media/')
+        ? `media-source://media_source${candidate}`
+        : candidate;
+
+      try {
+        const resolved = await this.hass.callWS({
+          type: 'media_source/resolve_media',
+          media_content_id: mediaContentId,
+          expires: (60 * 60 * 3)
+        });
+        const url = this._addCacheBustingTimestamp(resolved.url);
+        const companion = { media_content_id: mediaContentId, url };
+        this._livePhotoCompanionCache.set(itemId, companion);
+        this._log('🎞️ Live Photo companion resolved:', mediaContentId);
+        return companion;
+      } catch (error) {
+        this._log('🎞️ Live Photo companion candidate not available:', mediaContentId);
+      }
+    }
+
+    this._livePhotoCompanionCache.set(itemId, null);
+    return null;
+  }
+
+  _scheduleLivePhotoPlayback() {
+    this._clearLivePhotoTimer();
+
+    if (!this._isLivePhotoEnabled() ||
+        this._livePhotoPhase === 'pause' ||
+        !this._isImageItem(this.currentMedia) ||
+        this._isPaused ||
+        this._backgroundPaused ||
+        !this.mediaUrl) {
+      return;
+    }
+
+    const generation = ++this._livePhotoGeneration;
+    const itemId = this._getLivePhotoItemId(this.currentMedia);
+    this._livePhotoPhase = 'still';
+    const stillMs = Math.max(0.1, Number(this.config.live_photo?.still_duration) || 1) * 1000;
+
+    this._livePhotoTimer = setTimeout(() => {
+      this._startLivePhotoVideo(generation, itemId);
+    }, stillMs);
+  }
+
+  async _startLivePhotoVideo(generation, itemId) {
+    if (generation !== this._livePhotoGeneration ||
+        itemId !== this._getLivePhotoItemId(this.currentMedia) ||
+        this._isPaused ||
+        this._backgroundPaused) {
+      return;
+    }
+
+    const companion = await this._resolveLivePhotoCompanion(this.currentMedia);
+    if (!companion ||
+        generation !== this._livePhotoGeneration ||
+        itemId !== this._getLivePhotoItemId(this.currentMedia)) {
+      this._livePhotoPhase = 'idle';
+      return;
+    }
+
+    this._livePhotoVideoUrl = companion.url;
+    this._livePhotoPhase = 'video';
+    this._videoHasEnded = false;
+    this._videoTimerCount = 0;
+    this._videoPlayStartTime = null;
+    this.requestUpdate();
+  }
+
+  _onLivePhotoVideoEnded() {
+    if (this._livePhotoPhase !== 'video') return false;
+
+    this._clearLivePhotoTimer();
+    const generation = ++this._livePhotoGeneration;
+    const itemId = this._getLivePhotoItemId(this.currentMedia);
+    const pauseMs = Math.max(0, Number(this.config.live_photo?.pause_duration) || 10) * 1000;
+
+    this._livePhotoPhase = 'pause';
+    this._livePhotoVideoUrl = '';
+    this._hideBottomOverlaysForVideo = false;
+    this.requestUpdate();
+
+    this._livePhotoTimer = setTimeout(() => {
+      this._startLivePhotoVideo(generation, itemId);
+    }, pauseMs);
+    return true;
+  }
+
   // V4: Video event handlers
   _onVideoLoadStart() {
     this._log('Video load initiated:', this.mediaUrl);
@@ -3701,6 +3997,11 @@ export class MediaCard extends LitElement {
   }
 
   _onVideoEnded() {
+    if (this._onLivePhotoVideoEnded()) {
+      this._log('🎞️ Live Photo motion clip ended - returning to still frame');
+      return;
+    }
+
     const endTime = new Date();
     this._log(`🎬 Video ended at ${endTime.toLocaleTimeString()}:`, this.mediaUrl);
     
@@ -4797,9 +5098,10 @@ export class MediaCard extends LitElement {
     if (!this._isLocallyPaused()) {
       this._writeSharedQueueState();
     }
-
     // Cast-to-TV: push current item to TV on every image load
     this._pushCurrentToCast();
+
+    this._scheduleLivePhotoPlayback();
 
     // Trigger re-render to show updated metadata/counters
     this.requestUpdate();
@@ -11227,7 +11529,12 @@ export class MediaCard extends LitElement {
       `;
     }
     
-    if (!this.mediaUrl) {
+    const displayUrl = this._livePhotoPhase === 'video' && this._livePhotoVideoUrl
+      ? this._livePhotoVideoUrl
+      : this.mediaUrl;
+    const livePhotoVideoActive = this._livePhotoPhase === 'video' && !!this._livePhotoVideoUrl;
+
+    if (!displayUrl) {
       return html`<div class="placeholder">Resolving media URL...</div>`;
     }
 
@@ -11239,8 +11546,9 @@ export class MediaCard extends LitElement {
     // removed from the queue as a 404.
     // By using the resolved mediaUrl, the element type and src are always in sync.
     // Fallback: use media_content_type for extensionless URLs (e.g. Immich integration).
-    const resolvedUrlType = this.mediaUrl ? MediaUtils.detectFileType(this.mediaUrl) : null;
-    const isVideo = resolvedUrlType === 'video' ||
+    const resolvedUrlType = displayUrl ? MediaUtils.detectFileType(displayUrl) : null;
+    const isVideo = livePhotoVideoActive ||
+                    resolvedUrlType === 'video' ||
                     (resolvedUrlType !== 'image' && this.currentMedia?.media_content_type?.startsWith('video'));
 
     // Compute metadata overlay scale (defaults to 1.0; user configurable via metadata.scale)
@@ -11275,8 +11583,8 @@ export class MediaCard extends LitElement {
             preload="auto"
             playsinline
             crossorigin="anonymous"
-            ?loop=${(this.config.video_loop || false) && !(this.config.auto_advance_seconds > 0)}
-            ?autoplay=${this.config.video_autoplay !== false}
+            ?loop=${!livePhotoVideoActive && (this.config.video_loop || false) && !(this.config.auto_advance_seconds > 0)}
+            ?autoplay=${livePhotoVideoActive || this.config.video_autoplay !== false}
             ?muted=${this._getEffectiveMuteState()}
             @loadstart=${this._onVideoLoadStart}
             @error=${this._onMediaError}
@@ -11295,16 +11603,16 @@ export class MediaCard extends LitElement {
             @pointermove=${(e) => { e.stopPropagation(); this._showButtonsExplicitly = true; this._startActionButtonsHideTimer(); }}
             @touchstart=${(e) => { this._showButtonsExplicitly = true; this._startActionButtonsHideTimer(); this.requestUpdate(); }}
           >
-            <source src="${this.mediaUrl}" type="video/mp4" @error=${this._onSourceError}>
-            <source src="${this.mediaUrl}" type="video/webm" @error=${this._onSourceError}>
-            <source src="${this.mediaUrl}" type="video/ogg" @error=${this._onSourceError}>
-            <p>Your browser does not support the video tag. <a href="${this.mediaUrl}" target="_blank">Download the video</a> instead.</p>
+            <source src="${displayUrl}" type="video/mp4" @error=${this._onSourceError}>
+            <source src="${displayUrl}" type="video/webm" @error=${this._onSourceError}>
+            <source src="${displayUrl}" type="video/ogg" @error=${this._onSourceError}>
+            <p>Your browser does not support the video tag. <a href="${displayUrl}" target="_blank">Download the video</a> instead.</p>
           </video>
-          ${this._renderVideoInfo()}
+          ${livePhotoVideoActive ? html`` : this._renderVideoInfo()}
         ` : (this.config?.transition?.duration ?? 300) === 0 ? html`
           <!-- V5.6: Instant mode - single image, no layers -->
           <img 
-            src="${this.mediaUrl}" 
+            src="${displayUrl}" 
             alt="${this.currentMedia.title || 'Media'}"
             @error=${this._onMediaError}
             @load=${this._onMediaLoaded}

--- a/src/ui/media-card.js
+++ b/src/ui/media-card.js
@@ -11290,9 +11290,10 @@ export class MediaCard extends LitElement {
             @seeked=${this._onVideoSeeked}
             @volumechange=${this._onVideoVolumeChange}
             @click=${this._onVideoClickToggle}
-            @pointerdown=${(e) => { e.stopPropagation(); this._showButtonsExplicitly = true; this._startActionButtonsHideTimer(); this.requestUpdate(); }}
+            @dblclick=${this._handleDoubleTap}
+            @pointerdown=${(e) => { this._showButtonsExplicitly = true; this._startActionButtonsHideTimer(); this.requestUpdate(); }}
             @pointermove=${(e) => { e.stopPropagation(); this._showButtonsExplicitly = true; this._startActionButtonsHideTimer(); }}
-            @touchstart=${(e) => { e.stopPropagation(); this._showButtonsExplicitly = true; this._startActionButtonsHideTimer(); this.requestUpdate(); }}
+            @touchstart=${(e) => { this._showButtonsExplicitly = true; this._startActionButtonsHideTimer(); this.requestUpdate(); }}
           >
             <source src="${this.mediaUrl}" type="video/mp4" @error=${this._onSourceError}>
             <source src="${this.mediaUrl}" type="video/webm" @error=${this._onSourceError}>

--- a/src/ui/media-card.js
+++ b/src/ui/media-card.js
@@ -122,6 +122,7 @@ export class MediaCard extends LitElement {
       live_photo: {
         enabled: true,
         still_duration: 1,
+        repeat_delay: 10,
         pause_duration: 10,
         video_suffixes: ['_HEVC', '-HEVC', ''],
         video_extensions: ['MOV', 'mov', 'mp4', 'MP4', 'm4v', 'M4V'],
@@ -283,6 +284,7 @@ export class MediaCard extends LitElement {
     // Live Photo playback state. Used for iCloud-style still + companion video pairs.
     this._livePhotoPhase = 'idle';        // idle | still | video | pause
     this._livePhotoVideoUrl = '';
+    this._livePhotoVideoReady = false;
     this._livePhotoTimer = null;
     this._livePhotoCompanionCache = new Map();
     this._livePhotoGeneration = 0;
@@ -458,7 +460,7 @@ export class MediaCard extends LitElement {
     if (changedProperties.has('mediaUrl')) {
       // Wait for next frame to ensure video element is rendered
       requestAnimationFrame(() => {
-        const videoElement = this.shadowRoot?.querySelector('video');
+        const videoElement = this.shadowRoot?.querySelector('video:not(.live-photo-video)');
         
         if (videoElement && this.mediaUrl) {
           videoElement.load(); // Force browser to reload the video with new source
@@ -916,6 +918,7 @@ export class MediaCard extends LitElement {
       live_photo: {
         enabled: false,
         still_duration: 1,
+        repeat_delay: 10,
         pause_duration: 10,
         video_suffixes: ['_HEVC', '-HEVC', ''],
         video_extensions: ['MOV', 'mov', 'mp4', 'MP4', 'm4v', 'M4V'],
@@ -2272,7 +2275,7 @@ export class MediaCard extends LitElement {
           // - Short videos that loop: advance on FIRST timer fire after loop detected
           // - Long videos with max_duration: advance when timer count * interval >= max_duration
           // - Long videos without max_duration: never advance on timer (play to completion)
-          const videoElement = this.shadowRoot?.querySelector('video');
+          const videoElement = this.shadowRoot?.querySelector('video:not(.live-photo-video)');
           const maxDuration = this.config.video_max_duration;
           
           // Check if video is currently playing
@@ -2759,7 +2762,7 @@ export class MediaCard extends LitElement {
           await this.updateComplete; // Wait for Lit to finish rendering
           
           // Check if it's a video or image and reload appropriately
-          const videoElement = this.shadowRoot?.querySelector('video');
+          const videoElement = this.shadowRoot?.querySelector('video:not(.live-photo-video)');
           const imgElement = this.shadowRoot?.querySelector('.media-container > img');
           
           if (videoElement) {
@@ -3068,7 +3071,7 @@ export class MediaCard extends LitElement {
       // readyState > 0 means the OLD video has data, not that the NEW source is loading.
       // We MUST call load() to force browser to load the new source.
       await this.updateComplete;
-      const videoElement = this.shadowRoot?.querySelector('video');
+      const videoElement = this.shadowRoot?.querySelector('video:not(.live-photo-video)');
       if (videoElement) {
         this._log('🎬 Explicitly reloading video element for video→video transition');
         videoElement.load();
@@ -3583,6 +3586,7 @@ export class MediaCard extends LitElement {
     this._livePhotoGeneration++;
     this._livePhotoPhase = 'idle';
     this._livePhotoVideoUrl = '';
+    this._livePhotoVideoReady = false;
   }
 
   _getLivePhotoItemId(item = this.currentMedia) {
@@ -3705,6 +3709,7 @@ export class MediaCard extends LitElement {
 
     if (!this._isLivePhotoEnabled() ||
         this._livePhotoPhase === 'pause' ||
+        this._livePhotoPhase === 'video' ||
         !this._isImageItem(this.currentMedia) ||
         this._isPaused ||
         this._backgroundPaused ||
@@ -3739,23 +3744,56 @@ export class MediaCard extends LitElement {
     }
 
     this._livePhotoVideoUrl = companion.url;
+    this._livePhotoVideoReady = false;
     this._livePhotoPhase = 'video';
-    this._videoHasEnded = false;
-    this._videoTimerCount = 0;
-    this._videoPlayStartTime = null;
     this.requestUpdate();
   }
 
-  _onLivePhotoVideoEnded() {
+  _getLivePhotoRepeatDelaySeconds() {
+    const repeatDelay = this.config.live_photo?.repeat_delay;
+    if (repeatDelay !== undefined && repeatDelay !== null) {
+      return Math.max(0, Number(repeatDelay) || 0);
+    }
+    return Math.max(0, Number(this.config.live_photo?.pause_duration) || 10);
+  }
+
+  _onLivePhotoVideoCanPlay(e) {
+    if (this._livePhotoPhase !== 'video') return;
+    this._livePhotoVideoReady = true;
+    const video = e?.target;
+    if (video && video.paused) {
+      video.play().catch(error => {
+        if (error?.name !== 'AbortError') {
+          this._log('🎞️ Live Photo autoplay failed:', error);
+        }
+      });
+    }
+    this.requestUpdate();
+  }
+
+  _onLivePhotoVideoError() {
+    if (this._livePhotoPhase !== 'video') return;
+    const itemId = this._getLivePhotoItemId(this.currentMedia);
+    if (itemId) this._livePhotoCompanionCache.set(itemId, null);
+    this._livePhotoPhase = 'still';
+    this._livePhotoVideoUrl = '';
+    this._livePhotoVideoReady = false;
+    this._log('🎞️ Live Photo companion video failed - keeping still image visible');
+    this.requestUpdate();
+  }
+
+  _onLivePhotoVideoEnded(e) {
+    e?.stopPropagation?.();
     if (this._livePhotoPhase !== 'video') return false;
 
     this._clearLivePhotoTimer();
     const generation = ++this._livePhotoGeneration;
     const itemId = this._getLivePhotoItemId(this.currentMedia);
-    const pauseMs = Math.max(0, Number(this.config.live_photo?.pause_duration) || 10) * 1000;
+    const pauseMs = this._getLivePhotoRepeatDelaySeconds() * 1000;
 
     this._livePhotoPhase = 'pause';
     this._livePhotoVideoUrl = '';
+    this._livePhotoVideoReady = false;
     this._hideBottomOverlaysForVideo = false;
     this.requestUpdate();
 
@@ -3861,7 +3899,7 @@ export class MediaCard extends LitElement {
     
     // V5.6.4: Verify video element still exists in DOM before processing pause
     // Pause events can fire after navigation completes and video is removed
-    const videoElement = this.renderRoot?.querySelector('video');
+    const videoElement = this.renderRoot?.querySelector('video:not(.live-photo-video)');
     const isCurrentlyVideo = this._isVideoFile(this.currentMedia?.media_content_id || '');
     
     if (!videoElement || !isCurrentlyVideo) {
@@ -3949,7 +3987,7 @@ export class MediaCard extends LitElement {
   // Based on V4 lines 3259-3302
   // V5 ENHANCEMENT: If user has interacted with video, ignore video_max_duration and play to end
   async _shouldWaitForVideoCompletion() {
-    const videoElement = this.renderRoot?.querySelector('video');
+    const videoElement = this.renderRoot?.querySelector('video:not(.live-photo-video)');
     
     // No video playing, don't wait
     if (!videoElement || !this.mediaUrl || this.currentMedia?.media_content_type?.startsWith('image')) {
@@ -4025,7 +4063,7 @@ export class MediaCard extends LitElement {
       
       if (elapsedSeconds < autoAdvanceSeconds) {
         this._log(`🔁 Short video with loop enabled (${elapsedSeconds}s < ${autoAdvanceSeconds}s auto-advance) - restarting video`);
-        const videoElement = this.shadowRoot?.querySelector('video');
+        const videoElement = this.shadowRoot?.querySelector('video:not(.live-photo-video)');
         if (videoElement) {
           videoElement.currentTime = 0;
           videoElement.play().catch(err => this._log('Error restarting video:', err));
@@ -4142,7 +4180,7 @@ export class MediaCard extends LitElement {
   }
 
   _onVideoLoadedMetadata() {
-    const video = this.shadowRoot?.querySelector('video');
+    const video = this.shadowRoot?.querySelector('video:not(.live-photo-video)');
     if (video) {
       // V5.6.12: Apply user mute preference if valid, otherwise use config default
       const shouldBeMuted = this._getEffectiveMuteState();
@@ -4205,7 +4243,7 @@ export class MediaCard extends LitElement {
     this._log(`🔊 Mute toggled: ${currentEffective} → ${this._userMutePreference}`);
     
     // Apply to current video if one is playing
-    const video = this.shadowRoot?.querySelector('video');
+    const video = this.shadowRoot?.querySelector('video:not(.live-photo-video)');
     if (video) {
       video.muted = this._userMutePreference;
       
@@ -9429,6 +9467,24 @@ export class MediaCard extends LitElement {
       opacity: 0;
       z-index: 1;
     }
+
+    .media-container .live-photo-video {
+      position: absolute;
+      inset: 0;
+      width: 100%;
+      height: 100%;
+      object-fit: contain;
+      object-position: center center;
+      opacity: 0;
+      z-index: 3;
+      pointer-events: none;
+      background: transparent;
+      transition: opacity 120ms ease-in-out;
+    }
+
+    .media-container .live-photo-video.ready {
+      opacity: 1;
+    }
     
     /* V5.7: Edge fade effect - smooth rectangular fade using intersecting gradients */
     :host([data-edge-fade]) img,
@@ -9533,6 +9589,10 @@ export class MediaCard extends LitElement {
       max-height: none !important;
       object-fit: cover !important;
       object-position: center center;
+    }
+
+    :host([data-aspect-mode="viewport-fill"]) .media-container .live-photo-video {
+      object-fit: cover !important;
     }
     
     :host([data-aspect-mode="smart-scale"]) .media-container {
@@ -11529,9 +11589,7 @@ export class MediaCard extends LitElement {
       `;
     }
     
-    const displayUrl = this._livePhotoPhase === 'video' && this._livePhotoVideoUrl
-      ? this._livePhotoVideoUrl
-      : this.mediaUrl;
+    const displayUrl = this.mediaUrl;
     const livePhotoVideoActive = this._livePhotoPhase === 'video' && !!this._livePhotoVideoUrl;
 
     if (!displayUrl) {
@@ -11547,8 +11605,7 @@ export class MediaCard extends LitElement {
     // By using the resolved mediaUrl, the element type and src are always in sync.
     // Fallback: use media_content_type for extensionless URLs (e.g. Immich integration).
     const resolvedUrlType = displayUrl ? MediaUtils.detectFileType(displayUrl) : null;
-    const isVideo = livePhotoVideoActive ||
-                    resolvedUrlType === 'video' ||
+    const isVideo = resolvedUrlType === 'video' ||
                     (resolvedUrlType !== 'image' && this.currentMedia?.media_content_type?.startsWith('video'));
 
     // Compute metadata overlay scale (defaults to 1.0; user configurable via metadata.scale)
@@ -11583,8 +11640,8 @@ export class MediaCard extends LitElement {
             preload="auto"
             playsinline
             crossorigin="anonymous"
-            ?loop=${!livePhotoVideoActive && (this.config.video_loop || false) && !(this.config.auto_advance_seconds > 0)}
-            ?autoplay=${livePhotoVideoActive || this.config.video_autoplay !== false}
+            ?loop=${(this.config.video_loop || false) && !(this.config.auto_advance_seconds > 0)}
+            ?autoplay=${this.config.video_autoplay !== false}
             ?muted=${this._getEffectiveMuteState()}
             @loadstart=${this._onVideoLoadStart}
             @error=${this._onMediaError}
@@ -11608,7 +11665,7 @@ export class MediaCard extends LitElement {
             <source src="${displayUrl}" type="video/ogg" @error=${this._onSourceError}>
             <p>Your browser does not support the video tag. <a href="${displayUrl}" target="_blank">Download the video</a> instead.</p>
           </video>
-          ${livePhotoVideoActive ? html`` : this._renderVideoInfo()}
+          ${this._renderVideoInfo()}
         ` : (this.config?.transition?.duration ?? 300) === 0 ? html`
           <!-- V5.6: Instant mode - single image, no layers -->
           <img 
@@ -11637,6 +11694,21 @@ export class MediaCard extends LitElement {
               @load=${this._onMediaLoaded}
             />
           ` : ''}
+        ` : ''}
+        ${livePhotoVideoActive ? html`
+          <video
+            class="live-photo-video ${this._livePhotoVideoReady ? 'ready' : ''}"
+            preload="auto"
+            playsinline
+            autoplay
+            muted
+            crossorigin="anonymous"
+            src="${this._livePhotoVideoUrl}"
+            @canplay=${this._onLivePhotoVideoCanPlay}
+            @playing=${this._onLivePhotoVideoCanPlay}
+            @ended=${this._onLivePhotoVideoEnded}
+            @error=${this._onLivePhotoVideoError}
+          ></video>
         ` : ''}
         ${this._renderNavigationZones()}
         ${this._renderMetadataOverlay()}

--- a/src/ui/media-card.js
+++ b/src/ui/media-card.js
@@ -229,6 +229,8 @@ export class MediaCard extends LitElement {
     this._manualNavLoading = false;    // True from navigation commit until _onMediaLoaded/_onVideoCanPlay fires
     this._swipeTouchStartX = null;    // Touch start X for swipe gesture detection
     this._swipeTouchStartY = null;    // Touch start Y for swipe gesture detection
+    this._navigationGeneration = 0;    // Increments whenever newer navigation should obsolete async work
+    this._activeMediaPrepare = null;   // Current off-DOM image/video preparation task
     
     // V5.6.0: Play randomized option for panels
     this._playRandomized = false;      // Toggle for randomizing panel playback order
@@ -447,6 +449,7 @@ export class MediaCard extends LitElement {
     
     // Cleanup Live Photo playback timers
     this._clearLivePhotoPlayback();
+    this._cancelActiveMediaPrepare('card disconnect');
     this._revokeHeicObjectUrls();
   }
 
@@ -938,6 +941,13 @@ export class MediaCard extends LitElement {
         output_type: 'image/jpeg',
         quality: 0.92,
         ...config.heic
+      },
+      preload: {
+        enabled: true,
+        image_decode: true,
+        video_mode: 'metadata',
+        video_timeout_ms: 3000,
+        ...config.preload
       },
       // V5.6: Clock/Date Overlay defaults
       clock: {
@@ -1470,9 +1480,16 @@ export class MediaCard extends LitElement {
   async _loadNext() {
     // V5.6.7: Re-entrance guard - prevent concurrent calls to _loadNext
     if (this._isLoadingNext) {
-      this._log('⏭️ Skipping _loadNext - already in progress');
-      return;
+      if (!this._isManualNavigation) {
+        this._log('⏭️ Skipping _loadNext - already in progress');
+        return;
+      }
+      this._log('⏭️ Manual next requested while load is in progress - canceling stale preparation');
+      this._cancelActiveMediaPrepare('manual next');
+      this._isLoadingNext = false;
     }
+    this._navigationGeneration++;
+    const navigationGeneration = this._navigationGeneration;
     this._isLoadingNext = true;
 
     try {
@@ -1578,6 +1595,11 @@ export class MediaCard extends LitElement {
             this._log('🎞️ Skipping Live Photo companion video in slideshow queue:', item.media_content_id);
             item = await this.provider.getNext();
             hiddenCompanionAttempts++;
+          }
+
+          if (navigationGeneration !== this._navigationGeneration) {
+            this._log('⏭️ Discarding stale next-item provider result after newer navigation');
+            return;
           }
         
           if (item) {
@@ -1706,6 +1728,11 @@ export class MediaCard extends LitElement {
         return;
       }
 
+      if (navigationGeneration !== this._navigationGeneration) {
+        this._log('⏭️ Discarding stale next navigation before display');
+        return;
+      }
+
       // V5.6.8: Increment periodic refresh counter and check if refresh needed
       // Works for both sequential and random modes - provider handles mode-specific logic
       this._itemsSinceRefresh++;
@@ -1799,9 +1826,16 @@ export class MediaCard extends LitElement {
   async _loadPrevious() {
     // V5.6.7: Re-entrance guard - prevent concurrent calls to _loadPrevious
     if (this._isLoadingNext) {
-      this._log('⏮️ Skipping _loadPrevious - already in progress');
-      return;
+      if (!this._isManualNavigation) {
+        this._log('⏮️ Skipping _loadPrevious - already in progress');
+        return;
+      }
+      this._log('⏮️ Manual previous requested while load is in progress - canceling stale preparation');
+      this._cancelActiveMediaPrepare('manual previous');
+      this._isLoadingNext = false;
     }
+    this._navigationGeneration++;
+    const navigationGeneration = this._navigationGeneration;
     this._isLoadingNext = true;
 
     try {
@@ -1862,6 +1896,11 @@ export class MediaCard extends LitElement {
     }
     
     this._log('Going back to navigation queue item:', item.title, 'at index', this.navigationIndex);
+
+    if (navigationGeneration !== this._navigationGeneration) {
+      this._log('⏮️ Discarding stale previous navigation before display');
+      return;
+    }
     
     // Display the item
     this.currentMedia = item;
@@ -1969,6 +2008,8 @@ export class MediaCard extends LitElement {
 
   async _loadPanelItem(index) {
     // V5.6: Set flag to ignore video pause events during thumbnail click
+    this._navigationGeneration++;
+    this._cancelActiveMediaPrepare('panel navigation');
     this._navigatingAway = true;
     
     const item = this._panelQueue[index];
@@ -2029,6 +2070,8 @@ export class MediaCard extends LitElement {
 
   async _jumpToQueuePosition(queueIndex) {
     // V5.6: Set flag to ignore video pause events during thumbnail click
+    this._navigationGeneration++;
+    this._cancelActiveMediaPrepare('queue jump');
     this._navigatingAway = true;
     
     if (!this.navigationQueue || queueIndex < 0 || queueIndex >= this.navigationQueue.length) {
@@ -2944,6 +2987,39 @@ export class MediaCard extends LitElement {
     return cleanPath.endsWith('.heic') || cleanPath.endsWith('.heif');
   }
 
+  _isNavigationCurrent(expectedNavigationIndex, expectedGeneration) {
+    if (expectedGeneration !== undefined && expectedGeneration !== this._navigationGeneration) {
+      return false;
+    }
+    if (expectedNavigationIndex !== undefined && this._pendingNavigationIndex !== expectedNavigationIndex) {
+      return false;
+    }
+    return true;
+  }
+
+  _cancelActiveMediaPrepare(reason = 'navigation') {
+    const active = this._activeMediaPrepare;
+    if (!active) return;
+
+    active.cancelled = true;
+    active.abortController?.abort?.();
+    if (active.element) {
+      try {
+        if (active.type === 'video') {
+          active.element.pause?.();
+          active.element.removeAttribute('src');
+          active.element.load?.();
+        } else {
+          active.element.src = '';
+        }
+      } catch (error) {
+        // Best-effort cleanup only; stale generation checks still protect the UI.
+      }
+    }
+    this._activeMediaPrepare = null;
+    this._log(`⏭️ Canceled media preparation (${reason})`);
+  }
+
   _revokeHeicObjectUrls() {
     if (!this._heicObjectUrlCache) return;
 
@@ -2992,7 +3068,7 @@ export class MediaCard extends LitElement {
     return this._heicConverterPromise;
   }
 
-  async _prepareHeicDisplayUrl(url, expectedNavigationIndex) {
+  async _prepareHeicDisplayUrl(url, expectedNavigationIndex, expectedGeneration) {
     if (this.config?.heic?.enabled === false || (!this._isHeicMedia(this.currentMedia) && !this._isHeicMedia(url))) {
       return url;
     }
@@ -3004,10 +3080,13 @@ export class MediaCard extends LitElement {
     try {
       this._log('🖼️ Converting HEIC image for browser display:', this.currentMedia?.media_content_id || url);
       const converter = await this._loadHeicConverter();
+      if (!this._isNavigationCurrent(expectedNavigationIndex, expectedGeneration)) return '';
+
       const response = await fetch(url, { credentials: 'same-origin' });
       if (!response.ok) {
         throw new Error(`HEIC fetch failed with ${response.status}`);
       }
+      if (!this._isNavigationCurrent(expectedNavigationIndex, expectedGeneration)) return '';
 
       const inputBlob = await response.blob();
       const outputBlob = await converter({
@@ -3018,8 +3097,7 @@ export class MediaCard extends LitElement {
       const finalBlob = Array.isArray(outputBlob) ? outputBlob[0] : outputBlob;
       const objectUrl = URL.createObjectURL(finalBlob);
 
-      const currentNavIndex = this._pendingNavigationIndex ?? this.navigationIndex;
-      if (expectedNavigationIndex !== undefined && currentNavIndex !== expectedNavigationIndex) {
+      if (!this._isNavigationCurrent(expectedNavigationIndex, expectedGeneration)) {
         URL.revokeObjectURL(objectUrl);
         return '';
       }
@@ -3032,11 +3110,137 @@ export class MediaCard extends LitElement {
     }
   }
 
+  async _prepareMediaForDisplay(url, isVideo, expectedNavigationIndex, expectedGeneration) {
+    if (!url || this.config?.preload?.enabled === false) return true;
+    if (!this._isNavigationCurrent(expectedNavigationIndex, expectedGeneration)) return false;
+    this._cancelActiveMediaPrepare('new media prepare');
+
+    if (isVideo) {
+      return this._preloadVideoForDisplay(url, expectedNavigationIndex, expectedGeneration);
+    }
+
+    return this._preloadImageForDisplay(url, expectedNavigationIndex, expectedGeneration);
+  }
+
+  async _preloadImageForDisplay(url, expectedNavigationIndex, expectedGeneration) {
+    const image = new Image();
+    const abortController = new AbortController();
+    const active = { type: 'image', element: image, abortController, generation: expectedGeneration, cancelled: false };
+    this._activeMediaPrepare = active;
+
+    try {
+      await new Promise((resolve, reject) => {
+        const cleanup = () => {
+          image.onload = null;
+          image.onerror = null;
+          abortController.signal.removeEventListener('abort', onAbort);
+        };
+        const onAbort = () => {
+          cleanup();
+          reject(new DOMException('Image preload aborted', 'AbortError'));
+        };
+        image.onload = () => {
+          cleanup();
+          resolve();
+        };
+        image.onerror = () => {
+          cleanup();
+          reject(new Error('Image preload failed'));
+        };
+        abortController.signal.addEventListener('abort', onAbort, { once: true });
+        image.decoding = 'async';
+        image.loading = 'eager';
+        image.src = url;
+      });
+
+      if (this.config?.preload?.image_decode !== false && typeof image.decode === 'function') {
+        await image.decode().catch(() => {});
+      }
+
+      return this._isNavigationCurrent(expectedNavigationIndex, expectedGeneration);
+    } catch (error) {
+      if (error?.name === 'AbortError' || !this._isNavigationCurrent(expectedNavigationIndex, expectedGeneration)) {
+        return false;
+      }
+      this._log('⚠️ Image preload failed; falling back to normal image load:', error.message || error);
+      return true;
+    } finally {
+      if (this._activeMediaPrepare === active) {
+        this._activeMediaPrepare = null;
+      }
+    }
+  }
+
+  async _preloadVideoForDisplay(url, expectedNavigationIndex, expectedGeneration) {
+    const mode = this.config?.preload?.video_mode || 'metadata';
+    if (mode === 'none') return true;
+
+    const video = document.createElement('video');
+    const abortController = new AbortController();
+    const active = { type: 'video', element: video, abortController, generation: expectedGeneration, cancelled: false };
+    const eventName = mode === 'canplay' ? 'canplay' : 'loadedmetadata';
+    const timeoutMs = Math.max(250, Number(this.config?.preload?.video_timeout_ms) || 3000);
+    this._activeMediaPrepare = active;
+
+    try {
+      await new Promise((resolve, reject) => {
+        let timeoutId = null;
+        const cleanup = () => {
+          clearTimeout(timeoutId);
+          video.onloadedmetadata = null;
+          video.oncanplay = null;
+          video.onerror = null;
+          abortController.signal.removeEventListener('abort', onAbort);
+        };
+        const onReady = () => {
+          cleanup();
+          resolve();
+        };
+        const onAbort = () => {
+          cleanup();
+          reject(new DOMException('Video preload aborted', 'AbortError'));
+        };
+        timeoutId = setTimeout(() => {
+          cleanup();
+          resolve();
+        }, timeoutMs);
+        video[eventName === 'canplay' ? 'oncanplay' : 'onloadedmetadata'] = onReady;
+        video.onerror = () => {
+          cleanup();
+          resolve();
+        };
+        abortController.signal.addEventListener('abort', onAbort, { once: true });
+        video.preload = mode === 'canplay' ? 'auto' : 'metadata';
+        video.muted = true;
+        video.playsInline = true;
+        video.src = url;
+        video.load();
+      });
+
+      return this._isNavigationCurrent(expectedNavigationIndex, expectedGeneration);
+    } catch (error) {
+      if (error?.name === 'AbortError' || !this._isNavigationCurrent(expectedNavigationIndex, expectedGeneration)) {
+        return false;
+      }
+      return true;
+    } finally {
+      if (this._activeMediaPrepare === active) {
+        this._activeMediaPrepare = null;
+      }
+      try {
+        video.removeAttribute('src');
+        video.load();
+      } catch (error) {
+        // Best-effort cleanup.
+      }
+    }
+  }
+
   // V5.6: Helper to set mediaUrl with crossfade transition (validates first for images)
-  async _setMediaUrl(url, expectedNavigationIndex) {
+  async _setMediaUrl(url, expectedNavigationIndex, expectedGeneration = this._navigationGeneration) {
     // V5.6.7: Guard against stale async resolutions during rapid navigation
     // If expectedNavigationIndex is provided and doesn't match current pending index, abort
-    if (expectedNavigationIndex !== undefined && this._pendingNavigationIndex !== expectedNavigationIndex) {
+    if (!this._isNavigationCurrent(expectedNavigationIndex, expectedGeneration)) {
       this._log(`⏭️ Skipping stale media resolution (expected: ${expectedNavigationIndex}, current: ${this._pendingNavigationIndex})`);
       // Clear the navigation-in-progress flag when nothing else has claimed a pending
       // path (i.e. no sync nav or newer _loadNext() is in flight). Without this,
@@ -3086,10 +3290,14 @@ export class MediaCard extends LitElement {
       // If providerCheckResult is null, provider doesn't support checks (FolderProvider, SingleMediaProvider)
       // These providers discover files from disk, so 404s are unlikely - proceed without validation
 
-      displayUrl = await this._prepareHeicDisplayUrl(url, expectedNavigationIndex);
+      displayUrl = await this._prepareHeicDisplayUrl(url, expectedNavigationIndex, expectedGeneration);
       if (!displayUrl) {
         return;
       }
+    }
+
+    if (!await this._prepareMediaForDisplay(displayUrl, isVideo, expectedNavigationIndex, expectedGeneration)) {
+      return;
     }
     
     this.mediaUrl = displayUrl;
@@ -3211,6 +3419,7 @@ export class MediaCard extends LitElement {
     
     // V5.6.7: Capture pending index for async resolution guard
     const expectedIndex = this._pendingNavigationIndex;
+    const expectedGeneration = this._navigationGeneration;
     
     // Validate mediaId exists
     if (!mediaId) {
@@ -3221,7 +3430,7 @@ export class MediaCard extends LitElement {
     
     // If already a full URL, use it
     if (mediaId.startsWith('http')) {
-      await this._setMediaUrl(mediaId, expectedIndex);
+      await this._setMediaUrl(mediaId, expectedIndex, expectedGeneration);
       this.requestUpdate();
       return;
     }
@@ -3239,11 +3448,11 @@ export class MediaCard extends LitElement {
         // Add timestamp for auto-refresh (camera snapshots, etc.)
         const finalUrl = this._addCacheBustingTimestamp(resolved.url);
         
-        await this._setMediaUrl(finalUrl, expectedIndex);
+        await this._setMediaUrl(finalUrl, expectedIndex, expectedGeneration);
         this.requestUpdate();
       } catch (error) {
         console.error('[MediaCard] Failed to resolve media URL:', error);
-        await this._setMediaUrl('', expectedIndex);
+        await this._setMediaUrl('', expectedIndex, expectedGeneration);
         this._nextMediaUrl = '';
         this.requestUpdate();
       }
@@ -3268,7 +3477,7 @@ export class MediaCard extends LitElement {
         });
         this._log('✅ File exists and resolved to:', resolved.url);
         this._validationDepth = 0; // Reset on success
-        await this._setMediaUrl(resolved.url, expectedIndex);
+        await this._setMediaUrl(resolved.url, expectedIndex, expectedGeneration);
         this.requestUpdate();
         return; // Success - don't fall through to fallback
       } catch (error) {
@@ -3295,7 +3504,7 @@ export class MediaCard extends LitElement {
         }
         
         // Clear the current media to avoid showing broken state
-        await this._setMediaUrl('', expectedIndex);
+        await this._setMediaUrl('', expectedIndex, expectedGeneration);
         
         // Check recursion depth before recursive call
         this._validationDepth = (this._validationDepth || 0) + 1;
@@ -3314,7 +3523,7 @@ export class MediaCard extends LitElement {
 
     // Fallback: use as-is
     this._log('Using media ID as-is (fallback)');
-    await this._setMediaUrl(mediaId, expectedIndex);
+    await this._setMediaUrl(mediaId, expectedIndex, expectedGeneration);
     this.requestUpdate();
   }
 
@@ -3355,7 +3564,7 @@ export class MediaCard extends LitElement {
   _onMediaError(e) {
     if (this._livePhotoPhase === 'video') {
       const itemId = this._getLivePhotoItemId(this.currentMedia);
-      if (itemId) this._livePhotoCompanionCache.set(itemId, null);
+      if (itemId) this._livePhotoCompanionCache.delete(itemId);
       this._livePhotoPhase = 'idle';
       this._livePhotoVideoUrl = '';
       this._log('🎞️ Live Photo companion video failed - keeping still image visible');
@@ -3772,8 +3981,8 @@ export class MediaCard extends LitElement {
     const itemId = this._getLivePhotoItemId(item);
     if (!itemId || !this.hass) return false;
 
-    if (this._livePhotoCompanionVideoCache.has(itemId)) {
-      return this._livePhotoCompanionVideoCache.get(itemId);
+    if (this._livePhotoCompanionVideoCache.get(itemId) === true) {
+      return true;
     }
 
     for (const candidate of this._buildLivePhotoStillCandidatesForVideo(item)) {
@@ -3794,7 +4003,6 @@ export class MediaCard extends LitElement {
       }
     }
 
-    this._livePhotoCompanionVideoCache.set(itemId, false);
     return false;
   }
 
@@ -3862,7 +4070,7 @@ export class MediaCard extends LitElement {
     const itemId = this._getLivePhotoItemId(item);
     if (!itemId || !this.hass) return null;
 
-    if (this._livePhotoCompanionCache.has(itemId)) {
+    if (this._livePhotoCompanionCache.get(itemId)) {
       return this._livePhotoCompanionCache.get(itemId);
     }
 
@@ -3887,7 +4095,6 @@ export class MediaCard extends LitElement {
       }
     }
 
-    this._livePhotoCompanionCache.set(itemId, null);
     return null;
   }
 
@@ -3961,7 +4168,7 @@ export class MediaCard extends LitElement {
   _onLivePhotoVideoError() {
     if (this._livePhotoPhase !== 'video') return;
     const itemId = this._getLivePhotoItemId(this.currentMedia);
-    if (itemId) this._livePhotoCompanionCache.set(itemId, null);
+    if (itemId) this._livePhotoCompanionCache.delete(itemId);
     this._livePhotoPhase = 'still';
     this._livePhotoVideoUrl = '';
     this._livePhotoVideoReady = false;
@@ -5085,6 +5292,8 @@ export class MediaCard extends LitElement {
     // competing _loadNext() while the sync-driven URL resolution is in flight.
     // _navigatingAway is cleared by _onMediaLoaded / _onVideoCanPlay as normal.
     this._navigatingAway = true;
+    this._navigationGeneration++;
+    this._cancelActiveMediaPrepare('shared queue navigation');
     this._resolveMediaUrl();
     this.requestUpdate();
     // For media-index cards: kick off a background fetch to get fresher/fuller

--- a/src/ui/media-card.js
+++ b/src/ui/media-card.js
@@ -150,6 +150,10 @@ export class MediaCard extends LitElement {
     this._editorPreview = false; // V5.5: Flag to indicate card is in config editor preview
     this._cachedHeaderElement = null; // V5.6: Cached HA header element for viewport height calculation
     this._cachedHeaderSelector = null; // V5.6: Selector that found the cached header
+
+    // Cast-to-TV state
+    this._castEntityId = null;     // media_player entity currently mirroring this card
+    this._castPauseTimer = null;   // setTimeout handle for pre-end pause
     
     // V5.5: Side Panel System (Burst Review & Queue Preview)
     // Panel state
@@ -307,7 +311,11 @@ export class MediaCard extends LitElement {
 
   disconnectedCallback() {
     super.disconnectedCallback();
-    
+
+    // Stop any active cast so the TV doesn't show a frozen image after the
+    // card is removed or the user navigates away.
+    if (this._castEntityId) this._stopCast();
+
     this._log('🔌 Component disconnected - cleaning up resources');
     
     // NEW: Cleanup kiosk mode monitoring
@@ -3514,7 +3522,10 @@ export class MediaCard extends LitElement {
     if (!this._isLocallyPaused()) {
       this._writeSharedQueueState();
     }
-    
+
+    // Cast-to-TV: push current item to TV on every video ready
+    this._pushCurrentToCast();
+
     this.requestUpdate();
   }
 
@@ -3949,8 +3960,12 @@ export class MediaCard extends LitElement {
   }
 
   // Is cross-device sync available?
+  _getEffectiveSyncGroupId() {
+    return this.config?.shared_queue_id || null;
+  }
+
   _hasCrossDeviceSync() {
-    return !!(this.config?.shared_queue_id && this._getMediaIndexEntityId() && this.hass);
+    return !!(this._getEffectiveSyncGroupId() && this._getMediaIndexEntityId() && this.hass);
   }
 
   // ── Write path ──────────────────────────────────────────────────────────────
@@ -3959,7 +3974,7 @@ export class MediaCard extends LitElement {
   // must NOT set it, otherwise Device B's navigation will overwrite Device A's local
   // pause state.
   _writeSharedQueueState(pauseIntent = false) {
-    const id = this.config?.shared_queue_id;
+    const id = this._getEffectiveSyncGroupId();
     if (!id || !this.navigationQueue?.length) return;
 
     // Echo-prevention: skip the write that would bounce an incoming navigation sync
@@ -4016,7 +4031,7 @@ export class MediaCard extends LitElement {
   }
 
   async _writeSharedQueueStateToMediaIndex(pauseIntent = false) {
-    const id = this.config?.shared_queue_id;
+    const id = this._getEffectiveSyncGroupId();
     if (!id || !this.navigationQueue?.length) return;
     try {
       const entityId = this._getMediaIndexEntityId();
@@ -4780,7 +4795,10 @@ export class MediaCard extends LitElement {
     if (!this._isLocallyPaused()) {
       this._writeSharedQueueState();
     }
-    
+
+    // Cast-to-TV: push current item to TV on every image load
+    this._pushCurrentToCast();
+
     // Trigger re-render to show updated metadata/counters
     this.requestUpdate();
   }
@@ -5290,8 +5308,9 @@ export class MediaCard extends LitElement {
       : mediaType !== 'image';
     
     // Don't render anything if all buttons are disabled
+    const enableCast = this.config?.show_cast_button === true;
     const anyButtonEnabled = enablePause || showMuteButton || enableDebugButton || enableRefresh || enableFullscreen || 
-                            (showMediaIndexButtons && (enableFavorite || enableDelete || enableEdit || enableInfo || enableBurstReview || enableRelatedPhotos || enableOnThisDay)) ||
+                            (showMediaIndexButtons && (enableFavorite || enableDelete || enableEdit || enableInfo || enableBurstReview || enableRelatedPhotos || enableOnThisDay || enableCast)) ||
                             showQueueButton;
     if (!anyButtonEnabled) {
       return html``;
@@ -5420,6 +5439,14 @@ export class MediaCard extends LitElement {
             @click=${this._handleDeleteClick}
             title="Delete">
             <ha-icon icon="mdi:delete-outline"></ha-icon>
+          </button>
+        ` : ''}
+        ${showMediaIndexButtons && this.config?.show_cast_button === true ? html`
+          <button
+            class="action-btn cast-btn ${this._castEntityId ? 'active' : ''}"
+            @click=${this._handleCastButtonClick}
+            title="${this._castEntityId ? `Casting to ${this._castEntityId} (tap to stop)` : 'Cast to TV'}">
+            <ha-icon icon="${this._castEntityId ? 'mdi:cast-connected' : 'mdi:cast'}"></ha-icon>
           </button>
         ` : ''}
       </div>
@@ -6679,6 +6706,209 @@ export class MediaCard extends LitElement {
     const thumbnailUrl = await this._getMediaThumbnail(targetPath);
     
     this._showDeleteConfirmation(targetPath, thumbnailUrl, filename);
+  }
+
+  // ── Cast-to-TV handlers ────────────────────────────────────────────────────
+
+  async _handleCastButtonClick(e) {
+    e.stopPropagation();
+    if (this._castEntityId) {
+      this._stopCast();
+    } else {
+      await this._showCastPicker();
+    }
+  }
+
+  _showCastPicker() {
+    if (!this.hass) return;
+
+    const players = Object.entries(this.hass.states)
+      .filter(([id]) => id.startsWith('media_player.'))
+      .map(([id, state]) => ({
+        entity_id: id,
+        friendly_name: state.attributes?.friendly_name || id,
+        state: state.state,
+        is_roku: 'app_id' in (state.attributes || {}),
+      }))
+      .sort((a, b) => {
+        // Roku devices first, then alphabetical
+        if (a.is_roku !== b.is_roku) return a.is_roku ? -1 : 1;
+        return a.friendly_name.localeCompare(b.friendly_name);
+      });
+
+    if (!players.length) return;
+
+    const dialog = document.createElement('div');
+    dialog.className = 'cast-picker-overlay';
+    dialog.innerHTML = `
+      <div class="cast-picker-content">
+        <h3 class="cast-picker-title">Cast to…</h3>
+        <div class="cast-picker-list">
+          ${players.map(p => `
+            <button class="cast-picker-item${p.is_roku ? ' cast-picker-item--roku' : ''}" data-entity="${p.entity_id}">
+              <span class="cast-picker-name">${p.friendly_name}</span>
+              <span class="cast-picker-status">${p.state}${p.is_roku ? ' · Roku' : ''}</span>
+            </button>
+          `).join('')}
+        </div>
+        <button class="cast-picker-cancel">Cancel</button>
+      </div>
+    `;
+
+    const card = this.shadowRoot.querySelector('.card');
+    card.appendChild(dialog);
+
+    const cleanup = () => dialog.remove();
+    dialog.querySelector('.cast-picker-cancel').addEventListener('click', cleanup);
+    // Tap outside the content panel to dismiss
+    dialog.addEventListener('click', e => { if (e.target === dialog) cleanup(); });
+
+    dialog.querySelectorAll('.cast-picker-item').forEach(btn => {
+      btn.addEventListener('click', () => {
+        cleanup();
+        this._castEntityId = btn.dataset.entity;
+        this.requestUpdate();
+        // Send immediately to launch xcast (or update if already running).
+        // Then retry after 2.5 s — if xcast was cold-starting the first send
+        // wakes it up and the retry arrives once it's ready to display content.
+        this._pushCurrentToCast();
+        setTimeout(() => this._pushCurrentToCast(), 2500);
+      });
+    });
+  }
+
+  _stopCast() {
+    const entityId = this._castEntityId;
+    const isRoku = entityId && 'app_id' in (this.hass?.states[entityId]?.attributes || {});
+
+    this._castEntityId = null;
+    // Cancel any pending pre-end pause
+    if (this._castPauseTimer) {
+      clearTimeout(this._castPauseTimer);
+      this._castPauseTimer = null;
+    }
+    this.requestUpdate();
+
+    // Tell the Roku to stop via ECP keypress/Home — this sends it back to the
+    // home screen so the last cast image doesn't appear frozen on the TV.
+    // We use our own backend service because the Roku HA entity does not
+    // support the generic media_player.media_stop action.
+    if (isRoku && this.hass) {
+      this.hass.callService('media_index', 'stop_cast', { roku_entity_id: entityId }).catch(() => {});
+    }
+  }
+
+  async _pushCurrentToCast() {
+    if (!this._castEntityId || !this.hass || !this._currentMediaPath) return;
+
+    // Cancel any pre-end pause from the previous item
+    if (this._castPauseTimer) {
+      clearTimeout(this._castPauseTimer);
+      this._castPauseTimer = null;
+    }
+
+    const uri = this._currentMediaPath;
+    const entityId = this._castEntityId;
+    const fileType = MediaUtils.detectFileType(uri);
+    const ext = (uri.split('?')[0].split('.').pop() || '').toLowerCase();
+    const filename = uri.split('/').pop().split('?')[0];
+
+    // Resolve media-source:// URIs to a signed HTTP URL
+    let url = uri;
+    if (uri.startsWith('media-source://')) {
+      try {
+        const resp = await this.hass.callWS({
+          type: 'media_source/resolve_media',
+          media_content_id: uri,
+          expires: 3600,
+        });
+        if (resp?.url) url = resp.url;
+      } catch (err) {
+        this._log('⚠️ Cast: could not resolve media URL:', err);
+      }
+    }
+
+    // Detect Roku: Roku media_player entities have an app_id attribute
+    const playerAttrs = this.hass.states[entityId]?.attributes || {};
+    const isRoku = 'app_id' in playerAttrs;
+
+    if (isRoku) {
+      // Roku: use media_index.roku_ecp_cast which runs the xcast ECP call server-side.
+      // Direct browser→Roku ECP is blocked by CORS; this service bypasses that.
+      // xcast (app 687485) supports both video and images with automatic orientation.
+      const castData = {
+        roku_entity_id: entityId,
+      };
+      // Identify the file — prefer media_source_uri (exact match), then fs path, then filename substring
+      if (this._currentMetadata?.media_source_uri) {
+        castData.media_source_uri = this._currentMetadata.media_source_uri;
+      } else if (this._currentMetadata?.path) {
+        castData.file_path = this._currentMetadata.path;
+      } else {
+        castData.path_contains = filename;
+      }
+
+      // Route to the correct media_index instance (same pattern as get_random_items)
+      const wsCall = {
+        type: 'call_service',
+        domain: 'media_index',
+        service: 'roku_ecp_cast',
+        service_data: castData,
+        return_response: true,
+      };
+      if (this.config.media_index?.entity_id) {
+        wsCall.target = { entity_id: this.config.media_index.entity_id };
+      }
+
+      this._log(`🎬 Cast (Roku xcast) → ${entityId}: type=${fileType}, ${uri}`);
+      try {
+        const castResp = await this.hass.callWS(wsCall);
+        const r = castResp?.response ?? castResp;
+        this._log(`🎬 Cast (Roku xcast) cmd: ${r?.ecp_url_sent} → HTTP ${r?.ecp_status}`);
+      } catch (err) {
+        this._log('⚠️ Cast: roku_ecp_cast failed:', err);
+        return;
+      }
+    } else {
+      // DLNA / DMR / LG WebOS etc: proper MIME type required
+      const mimeMap = {
+        mp4: 'video/mp4', mov: 'video/quicktime', m4v: 'video/x-m4v',
+        avi: 'video/x-msvideo', mkv: 'video/x-matroska', wmv: 'video/x-ms-wmv',
+        webm: 'video/webm', ogv: 'video/ogg', '3gp': 'video/3gpp',
+        jpg: 'image/jpeg', jpeg: 'image/jpeg', png: 'image/png',
+        gif: 'image/gif', webp: 'image/webp', heic: 'image/heic',
+        bmp: 'image/bmp', tiff: 'image/tiff', tif: 'image/tiff',
+      };
+      const mimeType = mimeMap[ext] || (fileType === 'video' ? 'video/mp4' : 'image/jpeg');
+      const serviceData = {
+        entity_id: entityId,
+        media_content_id: url,
+        media_content_type: mimeType,
+      };
+      this._log(`🎬 Cast (DMR) → ${entityId}: ${mimeType} ${uri}`);
+      try {
+        await this.hass.callService('media_player', 'play_media', serviceData);
+      } catch (err) {
+        this._log('⚠️ Cast: play_media failed:', err);
+        return;
+      }
+    }
+
+    // Schedule a pre-end pause for videos so the TV doesn't snap to home screen
+    if (fileType === 'video') {
+      const duration = this._currentMetadata?.duration;
+      if (duration && parseFloat(duration) > 2) {
+        const pauseAfterMs = Math.max(1000, (parseFloat(duration) - 2) * 1000);
+        this._castPauseTimer = setTimeout(async () => {
+          this._castPauseTimer = null;
+          if (this._castEntityId !== entityId) return;
+          try {
+            await this.hass.callService('media_player', 'media_pause', { entity_id: entityId });
+            this._log(`🎬 Cast: pre-end pause sent to ${entityId}`);
+          } catch (_) {}
+        }, pauseAfterMs);
+      }
+    }
   }
 
   // V5.2: _convertToFilesystemPath removed - Media Index v1.1.0+ accepts media_source_uri directly
@@ -9982,7 +10212,112 @@ export class MediaCard extends LitElement {
     .confirm-btn:hover {
       background: var(--error-color-dark, #d32f2f);
     }
-    
+
+    /* ── Cast Picker Dialog ─────────────────────────────────────────────────── */
+    .cast-picker-overlay {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background: rgba(0, 0, 0, 0.7);
+      backdrop-filter: blur(4px);
+      z-index: 1000;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .cast-picker-content {
+      background: rgba(30, 30, 30, 0.92);
+      backdrop-filter: blur(20px);
+      -webkit-backdrop-filter: blur(20px);
+      border: 1px solid rgba(255, 255, 255, 0.12);
+      border-radius: 14px;
+      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.8);
+      min-width: 280px;
+      max-width: 420px;
+      width: 90%;
+      padding: 20px 16px 16px;
+      animation: dialogSlideIn 0.25s ease;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+
+    .cast-picker-title {
+      margin: 0 0 4px;
+      font-size: 15px;
+      font-weight: 600;
+      color: rgba(255, 255, 255, 0.9);
+      text-align: center;
+      letter-spacing: 0.3px;
+    }
+
+    .cast-picker-list {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      max-height: 320px;
+      overflow-y: auto;
+    }
+
+    .cast-picker-item {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      padding: 10px 14px;
+      border-radius: 10px;
+      border: 1px solid rgba(255, 255, 255, 0.1);
+      background: rgba(255, 255, 255, 0.06);
+      color: white;
+      cursor: pointer;
+      text-align: left;
+      transition: background 0.15s ease;
+    }
+
+    .cast-picker-item:hover {
+      background: rgba(255, 255, 255, 0.14);
+      border-color: rgba(255, 255, 255, 0.22);
+    }
+
+    .cast-picker-item--roku {
+      border-color: rgba(100, 200, 100, 0.35);
+      background: rgba(100, 200, 100, 0.08);
+    }
+
+    .cast-picker-item--roku:hover {
+      background: rgba(100, 200, 100, 0.18);
+    }
+
+    .cast-picker-name {
+      font-size: 14px;
+      font-weight: 500;
+    }
+
+    .cast-picker-status {
+      font-size: 11px;
+      opacity: 0.55;
+      margin-top: 1px;
+    }
+
+    .cast-picker-cancel {
+      margin-top: 4px;
+      padding: 9px;
+      border-radius: 10px;
+      border: 1px solid rgba(255, 255, 255, 0.1);
+      background: rgba(255, 255, 255, 0.06);
+      color: rgba(255, 255, 255, 0.6);
+      cursor: pointer;
+      font-size: 13px;
+      transition: background 0.15s ease;
+    }
+
+    .cast-picker-cancel:hover {
+      background: rgba(255, 255, 255, 0.12);
+      color: rgba(255, 255, 255, 0.9);
+    }
+
     /* Info Overlay Styles - Modern dropdown design */
     .info-overlay {
       position: absolute;


### PR DESCRIPTION
## Summary

Adds an optional iCloud Photos display preset and Live Photo playback loop to Media Card.

The `icloud_photos` preset points the card at a server-side iCloud sync folder in Home Assistant Media Source, enables recursive folder playback, allows images and videos, and turns on Live Photo pairing defaults. The `live_photo` options pair a still image with a companion video, show the still briefly, play the motion clip once, return to the still, wait, and repeat.

## Why

Home Assistant users can sync iCloud Photos into `/media` with a server-side add-on or integration, but Apple Live Photos arrive as separate still image and video files. Without pairing support, dashboards rotate those as unrelated media items. This makes Live Photos behave more like a single photo item while keeping Apple authentication and download work out of the browser.

## Notes

- The card does not authenticate to iCloud or download media.
- Companion videos can be hidden from the normal slideshow queue when `live_photo.hide_companion_videos` is enabled.
- The iCloud preset is just configuration convenience around existing Media Source folder playback.
- Documentation includes a Home Assistant add-on repository example for the sync side.

## Validation

- `node --check src/ui/media-card.js`
- `node --check ha-media-card.js`
- Manual bundle regeneration for `ha-media-card.js`
